### PR TITLE
fixes #3: remove actual version check and preserve resolutions

### DIFF
--- a/lib/utils/scenario-manager.js
+++ b/lib/utils/scenario-manager.js
@@ -12,6 +12,10 @@ module.exports = CoreObject.extend({
     return run('git', ['checkout', bowerFile]).then(function(){
       var bowerJSON = JSON.parse(fs.readFileSync(bowerFile));
 
+      if(!bowerJSON.resolutions){
+        bowerJSON.resolutions = {};
+      }
+
       fs.writeFileSync(bowerFile, JSON.stringify(manager._bowerJSONForScenario(bowerJSON, scenario), null, 2));
 
       return BowerHelpers.install(manager.project.root);
@@ -31,6 +35,9 @@ module.exports = CoreObject.extend({
 
       actualVersion = BowerHelpers.findVersion(dep, manager.project.root);
       expectedVersion = scenario.dependencies[dep];
+      if(actualVersion !== expectedVersion) {
+        manager.ui.writeLine(Chalk.yellow("Versions do not match: Expected: " + expectedVersion + " but saw " + actualVersion));
+      }
       manager.ui.writeLine("  " + dep + " " + actualVersion);
     });
   },
@@ -43,10 +50,8 @@ module.exports = CoreObject.extend({
       bowerJSON.dependencies[pkg] = scenario.dependencies[pkg];
       if (scenario.resolutions && scenario.resolutions[pkg]) {
         bowerJSON.resolutions[pkg] = scenario.resolutions[pkg];
-      } else if (scenario.dependencies && scenario.dependencies[pkg]) {
-        bowerJSON.resolutions[pkg] = scenario.dependencies[pkg];
       } else {
-        bowerJSON.resolutions[pkg] = {};
+        bowerJSON.resolutions[pkg] = scenario.dependencies[pkg];
       }
     });
 

--- a/lib/utils/scenario-manager.js
+++ b/lib/utils/scenario-manager.js
@@ -12,10 +12,6 @@ module.exports = CoreObject.extend({
     return run('git', ['checkout', bowerFile]).then(function(){
       var bowerJSON = JSON.parse(fs.readFileSync(bowerFile));
 
-      if(!bowerJSON.resolutions){
-        bowerJSON.resolutions = {};
-      }
-
       fs.writeFileSync(bowerFile, JSON.stringify(manager._bowerJSONForScenario(bowerJSON, scenario), null, 2));
 
       return BowerHelpers.install(manager.project.root);
@@ -35,9 +31,6 @@ module.exports = CoreObject.extend({
 
       actualVersion = BowerHelpers.findVersion(dep, manager.project.root);
       expectedVersion = scenario.dependencies[dep];
-      if(actualVersion != expectedVersion) {
-        manager.ui.writeLine(Chalk.yellow("Versions do not match: Expected: " + expectedVersion + " but saw " + actualVersion));
-      }
       manager.ui.writeLine("  " + dep + " " + actualVersion);
     });
   },
@@ -48,7 +41,13 @@ module.exports = CoreObject.extend({
 
     pkgs.forEach(function(pkg){
       bowerJSON.dependencies[pkg] = scenario.dependencies[pkg];
-      bowerJSON.resolutions[pkg] = scenario.dependencies[pkg];
+      if (scenario.resolutions && scenario.resolutions[pkg]) {
+        bowerJSON.resolutions[pkg] = scenario.resolutions[pkg];
+      } else if (scenario.dependencies && scenario.dependencies[pkg]) {
+        bowerJSON.resolutions[pkg] = scenario.dependencies[pkg];
+      } else {
+        bowerJSON.resolutions[pkg] = {};
+      }
     });
 
     return bowerJSON;


### PR DESCRIPTION
Fixes https://github.com/kategengler/ember-try/issues/3

So I included the suggestion that @rwjblue had, as well as I'm preserving the resolutions. Now in your scenario files you can optionally specify a resolutions object, like this:

```javascript
module.exports = {
  scenarios: [
    {
      name: 'ember-release',
      dependencies: {
        "ember": "components/ember#release"
      },
      resolutions: {
        "ember": "release"
      }
    },
    {
      name: 'ember-beta',
      dependencies: {
        "ember": "components/ember#beta"
      },
      resolutions: {
        "ember": "beta"
      }
    },
    {
      name: 'ember-canary',
      dependencies: {
        "ember": "components/ember#canary"
      },
      resolutions: {
        "ember": "canary"
      }
    }
  ]
};
```

or if you are not using shims, you can specify something like this:

```javascript
module.exports = {
  scenarios: [
    {
      name: 'ember-release',
      dependencies: {
        "ember": "ember#release"
      },
      resolutions: {
        "ember": "release"
      }
    },
    {
      name: 'ember-beta',
      dependencies: {
        "ember": "ember#beta"
      },
      resolutions: {
        "ember": "beta"
      }
    },
    {
      name: 'ember-canary',
      dependencies: {
        "ember": "ember#canary"
      },
      resolutions: {
        "ember": "canary"
      }
    }
  ]
};
```

I believe this should fix that problem that you had with the canary channel.