### PR TITLE
Do not require global `bower` or `ember` commands.

### DIFF
--- a/lib/tasks/testall.js
+++ b/lib/tasks/testall.js
@@ -6,6 +6,7 @@ var chalk           = require('chalk');
 var ScenarioManager = require('../utils/scenario-manager');
 var BowerHelpers    = require('../utils/bower-helpers');
 var run             = require('../utils/run');
+var findEmberPath   = require('./../utils/find-ember-path');
 
 module.exports = CoreObject.extend({
   run: function(options){
@@ -41,7 +42,12 @@ module.exports = CoreObject.extend({
   },
 
   _runTests: function(){
-    return run('ember', ['test'], {cwd: this.project.root})
+    var task = this;
+
+    return findEmberPath(task.project.root)
+      .then(function(emberPath){
+        return run('node', [emberPath, 'test'], {cwd: task.project.root})
+      })
       .then(function(){
         return RSVP.resolve(true);
       })

--- a/lib/tasks/try.js
+++ b/lib/tasks/try.js
@@ -4,6 +4,7 @@ var RSVP            = require('rsvp');
 var ScenarioManager = require('../utils/scenario-manager');
 var run             = require('../utils/run');
 var BowerHelpers    = require('../utils/bower-helpers');
+var findEmberPath   = require('./../utils/find-ember-path');
 
 module.exports = CoreObject.extend({
   run: function(scenario, commandName){
@@ -19,8 +20,11 @@ module.exports = CoreObject.extend({
     this.ScenarioManager = new ScenarioManager({ui: this.ui, project: this.project});
     return BowerHelpers.backupBowerFile(task.project.root).then(function(){
       return task.ScenarioManager.changeTo(scenario)
-        .then(function(){
-          return run('ember', [commandName], {cwd: task.project.root})
+        .then(function() {
+          return findEmberPath(task.project.root);
+        })
+        .then(function(emberPath){
+          return run('node', [emberPath, commandName], {cwd: task.project.root})
             .then(function(){
               return RSVP.resolve(true);
             })

--- a/lib/utils/bower-helpers.js
+++ b/lib/utils/bower-helpers.js
@@ -3,12 +3,32 @@ var fs     = require('fs-extra');
 var RSVP   = require('rsvp');
 var run    = require('./run');
 var rimraf = RSVP.denodeify(require('rimraf'));
+var resolve = RSVP.denodeify(require('resolve'));
 
 module.exports = {
+  findBowerPath: function(root) {
+    // find ember-cli's entry point module relative to
+    // the current projects root
+    return resolve('ember-cli', { basedir: root })
+      .then(function(emberPath) {
+        // find bower's entry point module relative to
+        // ember-cli's entry point script
+        return resolve('bower', { basedir: path.dirname(emberPath) });
+      })
+      .then(function(bowerPath) {
+        return path.join(bowerPath, '..', '..', 'bin', 'bower');
+      });
+  },
+
   install: function(root){
+    var helpers = this;
+
     return rimraf(path.join(root, 'bower_components'))
       .then(function() {
-        return run('bower', ['install'], {cwd: root});
+        return helpers.findBowerPath(root)
+      })
+      .then(function(bowerPath) {
+        return run('node', [bowerPath, 'install'], {cwd: root});
       });
   },
   resetBowerFile: function(root){

--- a/lib/utils/bower-helpers.js
+++ b/lib/utils/bower-helpers.js
@@ -4,12 +4,11 @@ var RSVP   = require('rsvp');
 var run    = require('./run');
 var rimraf = RSVP.denodeify(require('rimraf'));
 var resolve = RSVP.denodeify(require('resolve'));
+var findEmberPath = require('./find-ember-path');
 
 module.exports = {
   findBowerPath: function(root) {
-    // find ember-cli's entry point module relative to
-    // the current projects root
-    return resolve('ember-cli', { basedir: root })
+    return findEmberPath(root)
       .then(function(emberPath) {
         // find bower's entry point module relative to
         // ember-cli's entry point script

--- a/lib/utils/bower-helpers.js
+++ b/lib/utils/bower-helpers.js
@@ -1,13 +1,15 @@
 var path   = require('path');
 var fs     = require('fs-extra');
-var rimraf = require('rimraf');
 var RSVP   = require('rsvp');
 var run    = require('./run');
+var rimraf = RSVP.denodeify(require('rimraf'));
 
 module.exports = {
   install: function(root){
-    rimraf.sync(path.join(root, 'bower_components'));
-    return run('bower', ['install'], {cwd: root});
+    return rimraf(path.join(root, 'bower_components'))
+      .then(function() {
+        return run('bower', ['install'], {cwd: root});
+      });
   },
   resetBowerFile: function(root){
     var copy = RSVP.denodeify(fs.copy);
@@ -20,7 +22,7 @@ module.exports = {
   cleanup: function(root){
     var helpers = this;
     return helpers.resetBowerFile(root).then(function(){
-      rimraf.sync(path.join(root, 'bower.json.ember-try'));
+      return rimraf(path.join(root, 'bower.json.ember-try'));
     })
     .catch(function(){})
     .then(function(){

--- a/lib/utils/find-ember-path.js
+++ b/lib/utils/find-ember-path.js
@@ -1,0 +1,13 @@
+var path   = require('path');
+var RSVP   = require('rsvp');
+var resolve = RSVP.denodeify(require('resolve'));
+
+module.exports = function(root) {
+  // find ember-cli's entry point module relative to
+  // the current projects root
+  return resolve('ember-cli', { basedir: root })
+    .then(function(emberPath) {
+      // return the path to the ember command script
+      return path.join(emberPath, '..', '..', '..', 'bin', 'ember');
+    });
+};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "core-object": "^1.1.0",
     "fs-extra": "^0.18.0",
     "promise-map-series": "^0.2.1",
+    "resolve": "^1.1.6",
     "rimraf": "^2.3.2",
     "rsvp": "^3.0.17",
     "sync-exec": "^0.5.0"


### PR DESCRIPTION
This PR removes the need for global `ember` and `bower` commands.

* `ember` is looked up via a normal `resolve` from the consuming projects directory.
* `bower` is resolved relative to `ember`'s path.  This ensures that we are using the embedded version of Bower from Ember CLI (instead of requiring global `bower`).

Fixes #11.