### PR TITLE
Allow all command arguments to be passed through.

### DIFF
--- a/lib/commands/try.js
+++ b/lib/commands/try.js
@@ -10,9 +10,21 @@ module.exports = {
     '<command (Default: test)>'
   ],
 
+  getCommand: function() {
+    var args = process.argv.slice();
+    var tryIndex = args.indexOf(this.name);
+    var subcommandArgs = args.slice(tryIndex + 2);
+
+    if (subcommandArgs.length === 0) {
+      subcommandArgs.push('test');
+    }
+
+    return subcommandArgs;
+  },
+
   run: function(commandOptions, rawArgs) {
     var scenarioName = rawArgs[0];
-    var commandName = rawArgs[1] || 'test';
+    var commandArgs = this.getCommand();
 
     if (!scenarioName) {
       throw new Error('The `ember try` command requires a ' +
@@ -34,7 +46,7 @@ module.exports = {
       config: config
     });
 
-    return tryTask.run(scenario, commandName);
+    return tryTask.run(scenario, commandArgs);
   }
 };
 

--- a/lib/tasks/try.js
+++ b/lib/tasks/try.js
@@ -7,7 +7,7 @@ var BowerHelpers    = require('../utils/bower-helpers');
 var findEmberPath   = require('./../utils/find-ember-path');
 
 module.exports = CoreObject.extend({
-  run: function(scenario, commandName){
+  run: function(scenario, commandArgs){
     var task = this;
 
     process.on('SIGINT', function() {
@@ -24,7 +24,9 @@ module.exports = CoreObject.extend({
           return findEmberPath(task.project.root);
         })
         .then(function(emberPath){
-          return run('node', [emberPath, commandName], {cwd: task.project.root})
+          var args = [].concat(emberPath, commandArgs);
+
+          return run('node', args, {cwd: task.project.root})
             .then(function(){
               return RSVP.resolve(true);
             })


### PR DESCRIPTION
Allows:

```
ember try ember-canary test --server
```

Fixes #10.