### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An ember-cli addon to test against multiple bower dependencies, such as `ember` 
 ### Installation
 
 ```
-ember install:addon ember-try
+ember install ember-try
 ```
 
 ### Limitations


### PR DESCRIPTION
```bash
% ember install:addon ember-try
version: 0.2.3
The specified command install:addon is invalid. For available options, see `ember help`.
```

```bash
% ember install ember-try 
version: 0.2.3
Installed packages for tooling via npm.
Installed addon package.
```