### PR TITLE
Added an option to --skip-cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Especially useful to use on CI to test against multiple `ember` versions.
 
 #### `ember try <scenario> <command (Default: test)>`
 
-This command will run any `ember-cli` command with the specified scenario. The command will default to `ember test`. 
+This command will run any `ember-cli` command with the specified scenario. The command will default to `ember test`.
 
 For example:
 
@@ -37,13 +37,20 @@ or
   ember try ember-1.11-with-ember-data-beta-16 serve
 ```
 
+When running in a CI environment where changes are discarded you can skip reseting your environment back to its original state by specifying --skip-cleanup as an option to ember try.
+*Warning: If you use this option and, without cleaning up, build and deploy as the result of a passing test suite, it will build with the last set of dependencies ember try was run with.*
+
+```
+  ember try ember-1.11 test --skip-cleanup
+```
+
 #### `ember try:reset`
 
 This command restores the original `bower.json` from `bower.json.ember-try`, `rm -rf`s `bower_components` and runs `bower install`. For use if any of the other commands fail to clean up after (they run this by default on completion).
 
 ### Config
 
-Configuration will be read from a file in your ember app in `config/ember-try.js`. It should look like: 
+Configuration will be read from a file in your ember app in `config/ember-try.js`. It should look like:
 
 ```js
 module.exports = {
@@ -82,7 +89,7 @@ module.exports = {
 
 Scenarios are sets of dependencies (`bower` only). They can be specified exactly as in the `bower.json`
 The `name` can be used to try just one scenario using the `ember try` command.
- 
+
 If no `config/ember-try.js` file is present, the default config will be used. This is the current default config:
 
 ```js
@@ -110,7 +117,7 @@ If no `config/ember-try.js` file is present, the default config will be used. Th
 }
 ```
 
-See an example of using `ember-try` for CI [here](https://github.com/kategengler/ember-feature-flags/commit/aaf0226975c76630c875cf6b923fdc23b025aa79), and the resulting build [output](https://travis-ci.org/kategengler/ember-feature-flags/builds/55597086). 
+See an example of using `ember-try` for CI [here](https://github.com/kategengler/ember-feature-flags/commit/aaf0226975c76630c875cf6b923fdc23b025aa79), and the resulting build [output](https://travis-ci.org/kategengler/ember-feature-flags/builds/55597086).
 
 ### Special Thanks
 

--- a/lib/commands/testall.js
+++ b/lib/commands/testall.js
@@ -5,6 +5,10 @@ module.exports = {
   description: 'Runs `ember test` with each of the dependency scenarios specified in config.' ,
   works: 'insideProject',
 
+  availableOptions: [
+    { name: 'skip-cleanup',  type: Boolean, default: false },
+  ],
+
   run: function(commandOptions, rawArgs) {
 
     var config = require('../utils/config')({ project: this.project });

--- a/lib/commands/try.js
+++ b/lib/commands/try.js
@@ -10,10 +10,20 @@ module.exports = {
     '<command (Default: test)>'
   ],
 
+  availableOptions: [
+    { name: 'skip-cleanup',  type: Boolean, default: false },
+  ],
+
   getCommand: function() {
     var args = process.argv.slice();
     var tryIndex = args.indexOf(this.name);
     var subcommandArgs = args.slice(tryIndex + 2);
+
+    //remove ember-try options from the args that are passed on to ember
+    var skipIndex = subcommandArgs.indexOf('--skip-cleanup');
+    if(skipIndex !== -1){
+      subcommandArgs.splice(skipIndex, 1);
+    }
 
     if (subcommandArgs.length === 0) {
       subcommandArgs.push('test');
@@ -46,7 +56,7 @@ module.exports = {
       config: config
     });
 
-    return tryTask.run(scenario, commandArgs);
+    return tryTask.run(scenario, commandArgs, commandOptions);
   }
 };
 

--- a/lib/tasks/testall.js
+++ b/lib/tasks/testall.js
@@ -16,7 +16,14 @@ module.exports = CoreObject.extend({
 
     return BowerHelpers.backupBowerFile(task.project.root).then(function() {
       return mapSeries(scenarios, task._testVersion, task).then(function (results) {
-        return BowerHelpers.cleanup(task.project.root).then(function(){
+        var promise;
+        if(options.skipCleanup){
+          //create a fake promise for consistency
+          promise = RSVP.Promise.resolve();
+        } else {
+          promise = BowerHelpers.cleanup(task.project.root);
+        }
+        return promise.then(function(){
           task._printResults(scenarios, results);
           if(results.indexOf(false) > -1){
             process.exit(1);

--- a/lib/tasks/try.js
+++ b/lib/tasks/try.js
@@ -7,9 +7,9 @@ var BowerHelpers    = require('../utils/bower-helpers');
 var findEmberPath   = require('./../utils/find-ember-path');
 
 module.exports = CoreObject.extend({
-  run: function(scenario, commandArgs){
+  run: function(scenario, commandArgs, commandOptions){
     var task = this;
-
+    var commandName = commandOptions[1] || 'test';
     process.on('SIGINT', function() {
       task.ui.writeLine( "\nGracefully shutting down from SIGINT (Ctrl-C)" );
       BowerHelpers.cleanup(task.project.root).then(function(){
@@ -35,7 +35,14 @@ module.exports = CoreObject.extend({
             });
         })
         .then(function(result){
-          return BowerHelpers.cleanup(task.project.root).then(function(){
+          var promise;
+          if(commandOptions.skipCleanup){
+            //create a fake promise for consistency
+            promise = RSVP.Promise.resolve();
+          } else {
+            promise = BowerHelpers.cleanup(task.project.root);
+          }
+          return promise.then(function(){
             if(!result){
               task.ui.writeLine('');
               task.ui.writeLine('ember ' + commandName + ' with scenario ' + scenario.name + ' exited nonzero');


### PR DESCRIPTION
When running in a CI environment like travis the cleanup is just extra
time wasted.  —skip-cleanup will prevent the reset from running.

I only added this to the try command, if you want I’m happy to add it to testall as well, but I'm not sure if that has the same use case.

I did a thing with a fake promise in the try task that might be the wrong approach, but I'm not super familiar with writing commands and I wasn't sure what needed to be returned from where.  Alternatively I could skip the promise and just exit, but then the output would have to be managed in two places.  
All that is to say - let me know if you want me to do this another way.