### PR TITLE
Change default scenarios to use Ember's channels.

### DIFF
--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -17,21 +17,27 @@ function defaultConfig(){
   return {
     scenarios: [
       {
-        name: "ember-1.10",
+        name: "default",
+        dependencies: { } // no dependencies needed as the
+                          // default is already specified in
+                          // the consuming app's bower.json
+      },
+      {
+        name: "ember-release",
         dependencies: {
-          "ember": "1.10.0"
+          "ember": "release"
         }
       },
       {
-        name: "ember-1.11.1",
+        name: "ember-beta",
         dependencies: {
-          "ember": "1.11.1"
+          "ember": "beta"
         }
       },
       {
-        name: "ember-1.12.0-beta.1",
+        name: "ember-canary",
         dependencies: {
-          "ember": "1.12.0-beta.1"
+          "ember": "canary"
         }
       }
     ]


### PR DESCRIPTION
Given this change, we will automatically test (when no user specified config was provided) against release/beta/canary *AND* whatever version is manually specified in the `bower.json` of the consuming app/addon.

This provides the ability to have an app automatically tested against the next upcoming release in each channel, AND against the specific version that it is being developed against.