### PR TITLE
Disable bower install interactivity

### DIFF
--- a/lib/utils/bower-helpers.js
+++ b/lib/utils/bower-helpers.js
@@ -27,7 +27,7 @@ module.exports = {
         return helpers.findBowerPath(root)
       })
       .then(function(bowerPath) {
-        return run('node', [bowerPath, 'install'], {cwd: root});
+        return run('node', [bowerPath, 'install', '--config.interactive=false'], {cwd: root});
       });
   },
   resetBowerFile: function(root){


### PR DESCRIPTION
Allows ember-try to be used on a CI server like Travis.

See related ember-cli issue here: https://github.com/ember-cli/ember-cli/issues/4222