### PR TITLE
Add support for dev dependencies

### DIFF
--- a/lib/utils/scenario-manager.js
+++ b/lib/utils/scenario-manager.js
@@ -43,19 +43,31 @@ module.exports = CoreObject.extend({
   },
 
   _bowerJSONForScenario: function(bowerJSON, scenario){
-    if(!scenario.dependencies) { throw new Error("No dependencies specified for scenario " + scenario.name); }
-    var pkgs = Object.keys(scenario.dependencies);
+    if(!scenario.dependencies && !scenario.devDependencies) {
+      throw new Error("No dependencies specified for scenario " + scenario.name);
+    }
 
-    pkgs.forEach(function(pkg){
-      bowerJSON.dependencies[pkg] = scenario.dependencies[pkg];
-      if (scenario.resolutions && scenario.resolutions[pkg]) {
-        bowerJSON.resolutions[pkg] = scenario.resolutions[pkg];
-      } else {
-        bowerJSON.resolutions[pkg] = scenario.dependencies[pkg];
-      }
+    var self = this;
+    ['dependencies', 'devDependencies'].forEach(function(kindOfDependency) {
+      self._overrideBowerJSONDependencies(bowerJSON, scenario, kindOfDependency);
     });
 
     return bowerJSON;
+  },
+
+  _overrideBowerJSONDependencies: function(bowerJSON, scenario, kindOfDependency) {
+    if (!scenario[kindOfDependency]) { return; }
+    var pkgs = Object.keys(scenario[kindOfDependency]);
+
+    pkgs.forEach(function(pkg){
+      bowerJSON[kindOfDependency][pkg] = scenario[kindOfDependency][pkg];
+
+      if (scenario.resolutions && scenario.resolutions[pkg]) {
+        bowerJSON.resolutions[pkg] = scenario.resolutions[pkg];
+      } else {
+        bowerJSON.resolutions[pkg] = scenario[kindOfDependency][pkg];
+      }
+    });
   }
 });
 

--- a/test/scenario-manager-test.js
+++ b/test/scenario-manager-test.js
@@ -1,0 +1,49 @@
+var ScenarioManager = require('../lib/utils/scenario-manager');
+var should = require("should");
+
+describe('scenarioManager', function() {
+  describe('#_bowerJSONForScenario', function() {
+    it('should change specified bower dependency versions', function() {
+      var scenarioManager = new ScenarioManager();
+      var bowerJSON = { dependencies: { 'jQuery': '1.11.1' }, resolutions: {} };
+      var scenario =  { dependencies: { 'jQuery': '2.1.3' } };
+
+      bowerJSON = scenarioManager._bowerJSONForScenario(bowerJSON, scenario);
+
+      bowerJSON.dependencies['jQuery'].should.equal('2.1.3');
+    });
+
+    it('should change specified bower dev dependency versions', function() {
+      var scenarioManager = new ScenarioManager();
+      var bowerJSON = { devDependencies: { 'jQuery': '1.11.1' }, resolutions: {} };
+      var scenario =  { devDependencies: { 'jQuery': '2.1.3' } };
+
+      bowerJSON = scenarioManager._bowerJSONForScenario(bowerJSON, scenario);
+
+      bowerJSON.devDependencies['jQuery'].should.equal('2.1.3');
+    });
+
+    it('should add to resolutions', function() {
+      var scenarioManager = new ScenarioManager();
+      var bowerJSON = { dependencies: { 'jQuery': '1.11.1' }, resolutions: {} };
+      var scenario =  { dependencies: { 'jQuery': '2.1.3' } };
+
+      bowerJSON = scenarioManager._bowerJSONForScenario(bowerJSON, scenario);
+
+      bowerJSON.resolutions['jQuery'].should.equal('2.1.3');
+    });
+
+    it('should set custom resolutions', function() {
+      var scenarioManager = new ScenarioManager();
+      var bowerJSON = { dependencies: { 'ember': '1.13.5' }, resolutions: {} };
+      var scenario =  {
+        dependencies: { 'ember': 'components/ember#canary' },
+        resolutions:  { 'ember': 'canary' }
+      };
+
+      bowerJSON = scenarioManager._bowerJSONForScenario(bowerJSON, scenario);
+
+      bowerJSON.resolutions['ember'].should.equal('canary');
+    });
+  });
+});


### PR DESCRIPTION
This commit adds support for overriding bower packages specified in `devDependencies`.

I should add (a) test(s).