### PR TITLE
--allow-root flag on bower install

### DIFF
--- a/lib/utils/bower-helpers.js
+++ b/lib/utils/bower-helpers.js
@@ -27,7 +27,7 @@ module.exports = {
         return helpers.findBowerPath(root);
       })
       .then(function(bowerPath) {
-        return run('node', [bowerPath, 'install', '--config.interactive=false'], {cwd: root});
+        return run('node', [bowerPath, 'install', '--allow-root', '--config.interactive=false'], {cwd: root});
       });
   },
   resetBowerFile: function(root) {


### PR DESCRIPTION
By default `bower install` is not working with sudo or as root. The problem is that in many automated build systems all is run with sudo by default. This adds `--allow-root` flag when running `bower install` to avoid its fail.