### PR TITLE
Allow --config-path to be specified to ember-try commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,15 @@ This addon provides a few commands:
 #### `ember try:testall`
 
 This command will run `ember test` with each scenario's specified in the config and exit appropriately.
-Especially useful to use on CI to test against multiple `ember` versions.
+
+This command is especially useful to use on CI to test against multiple `ember` versions.
+
+In order to use an alternate config path or to group various scenarios together in a single `try:testall` run, you can use
+the `--config-path` option.
+
+```
+  ember try:testall --config-path="config/legacy-scenarios.js"
+```
 
 #### `ember try <scenario> <command (Default: test)>`
 
@@ -43,6 +51,13 @@ When running in a CI environment where changes are discarded you can skip reseti
 ```
   ember try ember-1.11 test --skip-cleanup
 ```
+
+In order to use an alternate config path or to group various scenarios, you can use the `--config-path` option.
+
+```
+  ember try ember-1.13 test --config-path="config/legacy-scenarios.js"
+```
+
 
 #### `ember try:reset`
 
@@ -84,7 +99,7 @@ module.exports = {
           'ember': 'components/ember#canary'
         },
         resolutions: {
-          'ember': 'canary' 
+          'ember': 'canary'
         }
       }
     },

--- a/lib/commands/testall.js
+++ b/lib/commands/testall.js
@@ -6,16 +6,20 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'skip-cleanup',  type: Boolean, default: false }
+    { name: 'skip-cleanup',  type: Boolean, default: false },
+    { name: 'config-path', type: String, default: 'config/ember-try.js' }
   ],
 
+  _getConfig: require('../utils/config'),
+  _TryEachTask: require('../tasks/try-each'),
+
   run: function(commandOptions, rawArgs) {
+    var config = this._getConfig({
+      project: this.project,
+      configPath: commandOptions.configPath
+    });
 
-    var config = require('../utils/config')({ project: this.project });
-
-    var TryEach = require('../tasks/try-each');
-
-    var tryEachTask = new TryEach({
+    var tryEachTask = new this._TryEachTask({
       ui: this.ui,
       project: this.project,
       config: config

--- a/lib/commands/try.js
+++ b/lib/commands/try.js
@@ -11,16 +11,26 @@ module.exports = {
   ],
 
   availableOptions: [
-    { name: 'skip-cleanup',  type: Boolean, default: false }
+    { name: 'skip-cleanup', type: Boolean, default: false },
+    { name: 'config-path', type: String, default: 'config/ember-try.js' }
   ],
 
-  getCommand: function() {
-    var args = process.argv.slice();
+  _getConfig: require('../utils/config'),
+  _TryEachTask: require('../tasks/try-each'),
+
+  getCommand: function(_argv) {
+    var args = (_argv || process.argv).slice();
     var tryIndex = args.indexOf(this.name);
     var subcommandArgs = args.slice(tryIndex + 2);
+    var skipIndex;
 
     // Remove ember-try options from the args that are passed on to ember
-    var skipIndex = subcommandArgs.indexOf('--skip-cleanup');
+    skipIndex = subcommandArgs.indexOf('--skip-cleanup');
+    if (skipIndex !== -1) {
+      subcommandArgs.splice(skipIndex, 1);
+    }
+
+    skipIndex = subcommandArgs.indexOf('--config-path');
     if (skipIndex !== -1) {
       subcommandArgs.splice(skipIndex, 1);
     }
@@ -41,16 +51,19 @@ module.exports = {
                       'scenario name to be specified.');
     }
 
-    var config = require('../utils/config')({ project: this.project });
+    var config = this._getConfig({
+      project: this.project,
+      configPath: commandOptions.configPath
+    });
+
     var scenario = findByName(config.scenarios, scenarioName);
 
     if (!scenario) {
       throw new Error('The `ember try` command requires a scenario ' +
-                      'specified in the ember-try.js config.');
+                      'specified in the config file.');
     }
 
-    var TryEachTask = require('../tasks/try-each');
-    var tryEachTask = new TryEachTask({
+    var tryEachTask = new this._TryEachTask({
       ui: this.ui,
       project: this.project,
       config: config,

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -2,7 +2,9 @@ var path = require('path');
 var fs   = require('fs');
 
 function config(options) {
-  var configFile = path.join(options.project.root, 'config', 'ember-try.js');
+  var relativePath = options.configPath || path.join('config', 'ember-try.js');
+  var configFile = path.join(options.project.root, relativePath);
+
   if (fs.existsSync(configFile)) {
     return require(configFile);
   } else {
@@ -50,3 +52,6 @@ function defaultConfig() {
     ]
   };
 }
+
+// Used for internal testing purposes.
+module.exports._defaultConfig = defaultConfig;

--- a/test/commands/testall-test.js
+++ b/test/commands/testall-test.js
@@ -1,0 +1,40 @@
+var should         = require('should');
+var TestallCommand = require('../../lib/commands/testall');
+
+var origTryEachTask = TestallCommand._TryEachTask;
+var origGetConfig = TestallCommand._getConfig;
+
+describe('commands/testall', function() {
+  describe('#run', function() {
+    var mockConfig;
+
+    function MockTryEachTask() { }
+    MockTryEachTask.prototype.run = function() { };
+
+    beforeEach(function() {
+      TestallCommand._getConfig = function() {
+        return mockConfig || { scenarios: [ ] };
+      };
+
+      TestallCommand._TryEachTask = MockTryEachTask;
+    });
+
+    afterEach(function() {
+      TestallCommand._TryEachTask = origTryEachTask;
+      TestallCommand._getConfig = origGetConfig;
+      mockConfig = null;
+    });
+
+    it('should pass the configPath to _getConfig', function() {
+      var configPath;
+      TestallCommand._getConfig = function(options) {
+        configPath = options.configPath;
+
+        return { scenarios: [ { name: 'foo' }]};
+      };
+
+      TestallCommand.run({ configPath: 'foo/bar/widget.js' }, ['foo']);
+      configPath.should.equal('foo/bar/widget.js');
+    });
+  });
+});

--- a/test/commands/try-test.js
+++ b/test/commands/try-test.js
@@ -1,0 +1,80 @@
+var should        = require('should');
+var TryCommand    = require('../../lib/commands/try');
+
+var origTryEachTask = TryCommand._TryEachTask;
+var origGetConfig = TryCommand._getConfig;
+
+describe('commands/try', function() {
+  describe('getCommand', function() {
+    it('removes `--skip-cleanup` from resulting arguments', function() {
+      var args = TryCommand.getCommand(['ember', 'try', 'foo-bar-scenario', 'build', '--skip-cleanup']);
+
+      args.should.eql(['build']);
+    });
+
+    it('removes `--config-path` from resulting arguments', function() {
+      var args = TryCommand.getCommand(['ember', 'try', 'foo-bar-scenario', 'build', '--config-path']);
+
+      args.should.eql(['build']);
+    });
+
+    it('removes both `--config-path` and `--skip-cleanup` from resulting arguments', function() {
+      var args = TryCommand.getCommand([
+        'ember', 'try', 'foo-bar-scenario', 'build', '--config-path', '--skip-cleanup'
+      ]);
+
+      args.should.eql(['build']);
+    });
+
+    it('adds `test` if no other subcommand arguments were supplied', function() {
+      var args = TryCommand.getCommand(['ember', 'try', 'foo-bar-scenario']);
+
+      args.should.eql(['test']);
+    });
+  });
+
+  describe('#run', function() {
+    var mockConfig;
+
+    function MockTryEachTask() { }
+    MockTryEachTask.prototype.run = function() { };
+
+    beforeEach(function() {
+      TryCommand._getConfig = function() {
+        return mockConfig || { scenarios: [ ] };
+      };
+
+      TryCommand._TryEachTask = MockTryEachTask;
+    });
+
+    afterEach(function() {
+      TryCommand._TryEachTask = origTryEachTask;
+      TryCommand._getConfig = origGetConfig;
+      mockConfig = null;
+    });
+
+    it('should throw if no scenario is provided', function() {
+      (function() {
+        TryCommand.run({}, []);
+      }).should.throw(/requires a scenario name to be specified/);
+    });
+
+    it('should pass the configPath to _getConfig', function() {
+      var configPath;
+      TryCommand._getConfig = function(options) {
+        configPath = options.configPath;
+
+        return { scenarios: [ { name: 'foo' }]};
+      };
+
+      TryCommand.run({ configPath: 'foo/bar/widget.js' }, ['foo']);
+      configPath.should.equal('foo/bar/widget.js');
+    });
+
+    it('should throw if a scenario was not found for the scenarioName provided', function() {
+      (function() {
+        TryCommand.run({ }, ['foo']);
+      }).should.throw(/requires a scenario specified in the config file/);
+    });
+  });
+});

--- a/test/utils/config-test.js
+++ b/test/utils/config-test.js
@@ -1,0 +1,65 @@
+var should        = require('should');
+var RSVP          = require('rsvp');
+var fs            = require('fs-extra');
+var path          = require('path');
+var tmp           = require('tmp-sync');
+var getConfig     = require('../../lib/utils/config');
+var defaultConfig = getConfig._defaultConfig;
+
+var remove = RSVP.denodeify(fs.remove);
+var stat = RSVP.denodeify(fs.stat);
+var root = process.cwd();
+var tmproot = path.join(root, 'tmp');
+var tmpdir;
+
+describe('utils/config', function() {
+  var project;
+
+  beforeEach(function() {
+    tmpdir = tmp.in(tmproot);
+    process.chdir(tmpdir);
+    project = { root: tmpdir };
+  });
+
+  afterEach(function() {
+    process.chdir(root);
+    return remove(tmproot);
+  });
+
+  function generateConfigFile(contents, _filename) {
+    var filename = _filename || 'ember-try.js';
+    fs.mkdirsSync('config');
+
+    fs.writeFileSync('config/' + filename, contents, { encoding: 'utf8' });
+  }
+
+  it('uses specified options.configFile if present', function() {
+    generateConfigFile('module.exports = { scenarios: [ { qux: "baz" }] };', 'non-default.js');
+
+    var config = getConfig({ project: project, configPath: 'config/non-default.js' });
+    config.scenarios.should.have.length(1);
+    config.scenarios[0].qux.should.equal('baz');
+  });
+
+  it('uses projects config/ember-try.js if present', function() {
+    generateConfigFile('module.exports = { scenarios: [ { foo: "bar" }] };');
+
+    var config = getConfig({ project: project });
+    config.scenarios.should.have.length(1);
+    config.scenarios[0].foo.should.equal('bar');
+  });
+
+  it('uses default config if project.root/config/ember-try.js is not present', function() {
+    var config = getConfig({ project: project });
+    config.should.eql(defaultConfig());
+  });
+
+  it('uses specified options.configFile over project config/ember-try.js', function() {
+    generateConfigFile('module.exports = { scenarios: [ { qux: "baz" }] };', 'non-default.js');
+    generateConfigFile('module.exports = { scenarios: [ { foo: "bar" }] };'); // should not be used
+
+    var config = getConfig({ project: project, configPath: 'config/non-default.js' });
+    config.scenarios.should.have.length(1);
+    config.scenarios[0].qux.should.equal('baz');
+  });
+});


### PR DESCRIPTION
This allows groups of configurations to be used with various commands.

For example, it would be nice in ember-test-helpers to group "legacy" Ember versions together and run them as a single matrix build with:

```
ember try:testall --config-path=config/legacy-scenarios.js
```

Then we could run current scenarios in another matrix build like:

```
ember try:testall --config-path=config/current-scenarios.js
```