### PR TITLE
Expose environment variable for currently running scenario.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Can only change versions for Ember 1.10+ due to template compiler changes that t
 
 This addon provides a few commands:
 
-#### `ember try:testall`
+### `ember try:testall`
 
 This command will run `ember test` with each scenario's specified in the config and exit appropriately.
 
@@ -28,6 +28,9 @@ the `--config-path` option.
 ```
   ember try:testall --config-path="config/legacy-scenarios.js"
 ```
+
+If you need to know the scenario that is being ran (i.e. to customize a test output file name) you can use the `EMBER_TRY_CURRENT_SCENARIO`
+environment variable.
 
 #### `ember try <scenario> <command (Default: test)>`
 

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -45,6 +45,8 @@ module.exports = CoreObject.extend({
     var task = this;
     return task.ScenarioManager.changeTo(scenario)
       .then(function(scenarioDependencyState) {
+        process.env.EMBER_TRY_CURRENT_SCENARIO = scenario.name;
+
         var runResults = {
           scenario: scenario.name,
           dependencyState: scenarioDependencyState
@@ -77,6 +79,8 @@ module.exports = CoreObject.extend({
   },
 
   _optionallyCleanup: function(options) {
+    delete process.env.EMBER_TRY_CURRENT_SCENARIO;
+
     var task = this;
     var promise;
     if (options.skipCleanup) {


### PR DESCRIPTION
In some circumstances, you may want to know the scenario currently being ran (i.e. one example is generating test results files for each scenario).  This exposes the current scenario name as `EMBER_TRY_CURRENT_SCENARIO` just before running the command and resets it just before cleaning up.

My personal use case for this is to generate a testem report file for each scenario, and to do that I need to be able to detect the scenario in my projects Testem config...


See https://github.com/rwjblue/ember-collection/commit/58c88088ed8abf511f88208932c965f553c0f9c0 for an example of how I tried to work around this (and failed)...