### PR TITLE
Quiet npm warnings by appeasing it with changes to the fixture package.json

### DIFF
--- a/test/bower-adapter-test.js
+++ b/test/bower-adapter-test.js
@@ -38,13 +38,13 @@ describe('bowerAdapter', function() {
     it('accounts for legacy format', function() {
       var scenarioDepSet = {
         dependencies: {
-          "ember": "components/ember#beta"
+          ember: 'components/ember#beta'
         },
         devDependencies: {
-          "ember-data": "~2.2.0"
+          'ember-data': '~2.2.0'
         },
         resolutions: {
-          "ember": "beta"
+          ember: 'beta'
         }
       };
       var results = new BowerAdapter({cwd: tmpdir})._getDependencySetAccountingForDeprecatedTopLevelKeys(scenarioDepSet);
@@ -55,23 +55,23 @@ describe('bowerAdapter', function() {
       var scenarioDepSet = {
         bower: {
           dependencies: {
-            "ember": "components/ember#release"
+            ember: 'components/ember#release'
           },
           devDependencies: {
-            "ember-data": "~2.1.0"
+            'ember-data': '~2.1.0'
           },
           resolutions: {
-            "ember": "release"
+            ember: 'release'
           }
         },
         dependencies: {
-          "ember": "components/ember#beta"
+          ember: 'components/ember#beta'
         },
         devDependencies: {
-          "ember-data": "~2.2.0"
+          'ember-data': '~2.2.0'
         },
         resolutions: {
-          "ember": "beta"
+          ember: 'beta'
         }
       };
 

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,6 +1,15 @@
 {
   "name": "a-test-project",
   "devDependencies": {
-    "ember-data": "2.3.3"
-  }
+    "ember-feature-flags": "2.0.0"
+  },
+  "repository": "kategengler/ember-try",
+  "private": true,
+  "version": "1.0.0",
+  "description": "A test thing",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": ""
 }

--- a/test/npm-adapter-test.js
+++ b/test/npm-adapter-test.js
@@ -82,7 +82,7 @@ describe('npmAdapter', function() {
   describe('#_packageJSONForDependencySet', function() {
     it('changes specified dependency versions', function() {
       var npmAdapter = new NpmAdapter({cwd: tmpdir});
-      var packageJSON = { devDependencies: { 'ember-data': '2.2.1' }, dependencies: { 'ember-cli-babel': '5.0.0'} };
+      var packageJSON = { devDependencies: { 'ember-feature-flags': '1.0.0' }, dependencies: { 'ember-cli-babel': '5.0.0'} };
       var depSet =  { dependencies: { 'ember-cli-babel': '6.0.0' } };
 
       var resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
@@ -92,12 +92,12 @@ describe('npmAdapter', function() {
 
     it('changes specified bower dev dependency versions', function() {
       var npmAdapter = new NpmAdapter({cwd: tmpdir});
-      var packageJSON = { devDependencies: { 'ember-data': '2.2.1' }, dependencies: { 'ember-cli-babel': '5.0.0'} };
-      var depSet =  { devDependencies: { 'ember-data': '2.3.0' } };
+      var packageJSON = { devDependencies: { 'ember-feature-flags': '1.0.0' }, dependencies: { 'ember-cli-babel': '5.0.0'} };
+      var depSet =  { devDependencies: { 'ember-feature-flags': '2.0.1' } };
 
       var resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
 
-      resultJSON.devDependencies['ember-data'].should.equal('2.3.0');
+      resultJSON.devDependencies['ember-feature-flags'].should.equal('2.0.1');
     });
   });
 });

--- a/test/utils/config-test.js
+++ b/test/utils/config-test.js
@@ -56,7 +56,7 @@ describe('utils/config', function() {
 
   it('uses specified options.configFile over project config/ember-try.js', function() {
     generateConfigFile('module.exports = { scenarios: [ { qux: "baz" }] };', 'non-default.js');
-    generateConfigFile('module.exports = { scenarios: [ { foo: "bar" }] };'); // should not be used
+    generateConfigFile('module.exports = { scenarios: [ { foo: "bar" }] };'); // Should not be used
 
     var config = getConfig({ project: project, configPath: 'config/non-default.js' });
     config.scenarios.should.have.length(1);


### PR DESCRIPTION
- Some JSCS fixes
- Use ember-feature-flags instead of ember-data as sample dep to not see
  warnings