### PR TITLE
Fix bug: options were not being passed to the command run by `try`

### DIFF
--- a/all-commands.sh
+++ b/all-commands.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -ex
+
+# try:testall
+ember try:testall
+
+# all styles of options for ember-try's own option
+ember try:testall --skip-cleanup
+ember try:testall --skip-cleanup=true
+ember try:testall --skip-cleanup true
+
+# config-path option
+ember try:testall --config-path='test/fixtures/dummy-ember-try-config.js'
+
+# both ember-try options
+ember try:testall --config-path='test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
+
+# try <scenario>
+ember try default
+
+# custom command
+ember try default help
+
+# skip-cleanup option
+ember try default --skip-cleanup
+
+# The following two DO NOT CURRENTLY WORK
+# ember try default --skip-cleanup=true
+# ember try default --skip-cleanup true
+
+# config-path option; DOES NOT CURRENTLY WORK
+# ember try test1 --config-path='test/fixtures/dummy-ember-try-config.js'
+
+# both ember-try options; DOES NOT CURRENTLY WORK
+# ember try test1 --config-path='test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
+
+# custom command with all styles of options
+ember try default help --json
+ember try default help --json=true
+ember try default help --json true
+
+# custom command mixed with ember try's own option
+ember try default help --json --skip-cleanup
+
+# try:reset
+ember try:reset

--- a/lib/utils/run-command.js
+++ b/lib/utils/run-command.js
@@ -8,7 +8,7 @@ module.exports = function(root, commandArgs, opts) {
   return findEmberPath(root)
     .then(function(emberPath) {
       options = extend({cwd: root}, opts);
-      return run('node', [emberPath, commandArgs], options);
+      return run('node', [].concat(emberPath, commandArgs), options);
     })
     .then(function() {
       return RSVP.resolve(true);

--- a/lib/utils/run.js
+++ b/lib/utils/run.js
@@ -4,6 +4,11 @@ var spawn = require('child_process').spawn;
 function run(command, args, opts) {
   opts = opts || {};
   opts.stdio = 'inherit';
+
+  if (process.env.SHUT_UP) {
+    opts.stdio = 'ignore';
+  }
+
   return new RSVP.Promise(function(resolve, reject) {
     var p = spawn(command, args, opts);
     var didTimeout = false;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "client-test": "ember try:testall",
+    "client-test": "./all-commands.sh",
     "node-test": "mocha .",
     "lint": "jshint lib test",
     "jscs": "jscs lib test",

--- a/test/fixtures/dummy-ember-try-config.js
+++ b/test/fixtures/dummy-ember-try-config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'test1',
+      bower: {
+        dependencies: {
+          'ember': '1.10.0'
+        }
+      }
+    }
+  ]
+};

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -433,6 +433,46 @@ describe('tryEach', function() {
       });
     });
 
+    it('allows passing options to the command run', function() {
+      // With stubbed dependency manager, timing out is warning for accidentally not using the stub
+      this.timeout(5000);
+
+      var config = {
+        scenarios: [{
+          name: 'first',
+          dependencies: {
+            ember: '1.13.0'
+          }
+        }]
+      };
+
+      var output = [];
+      var outputFn = function(log) {
+        output.push(log);
+      };
+
+      var mockedExit = function(code) {
+        code.should.equal(0, 'exits 0 when all scenarios succeed');
+      };
+
+      var TryEachTask = require('../../lib/tasks/try-each');
+      var tryEachTask = new TryEachTask({
+        ui: {writeLine: outputFn},
+        project: {root: tmpdir},
+        config: config,
+        commandArgs: ['help', '--json', 'true'],
+        dependencyManagerAdapters: [new StubDependencyAdapter()],
+        _exit: mockedExit
+      });
+
+      return tryEachTask.run(config.scenarios, {}).then(function() {
+        output.should.containEql('Scenario first: SUCCESS', 'Passing scenario means options were passed along');
+      }).catch(function(err) {
+        console.log(err);
+        true.should.equal(false, 'Assertions should run');
+      });
+    });
+
     it('sets EMBER_TRY_CURRENT_SCENARIO', function() {
       // With stubbed dependency manager, timing out is warning for accidentally not using the stub
       this.timeout(100);

--- a/test/utils/run-command-test.js
+++ b/test/utils/run-command-test.js
@@ -1,0 +1,36 @@
+var should      = require('should');
+var mockery     = require('mockery');
+var RSVP        = require('rsvp');
+
+describe('utils/run-command', function() {
+  beforeEach(function() {
+    mockery.enable({
+      warnOnUnregistered: false,
+      useCleanCache: true
+    });
+  });
+
+  afterEach(function() {
+    mockery.deregisterAll();
+    mockery.disable();
+  });
+
+  it('passes arguments to run', function() {
+    var mockedRun = function(command, args) {
+      command.should.equal('node');
+      args[0].should.match(/.*\/ember/);
+      args[1].should.equal('help');
+      args[2].should.equal('--json');
+      args[3].should.equal('true');
+      return RSVP.resolve(0);
+    };
+
+    mockery.registerMock('./run', mockedRun);
+
+    var runCommand  = require('../../lib/utils/run-command');
+
+    return runCommand('rootPath', ['help', '--json', 'true'], {}).then(function(result){
+      result.should.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
Example of what will now work again: `ember try default help --json true`

- Add a script to run various permutations of supported commands, use it
in CI. (This uncovered a few other commands that are not working,
but it seems like they never did. Will open other issues or address.)