### PR TITLE
Make commands configurable and add `try:each` command, soft-deprecating `testall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ Can only change versions for Ember 1.10+ due to template compiler changes that t
 
 This addon provides a few commands:
 
-### `ember try:testall`
+### `ember try:each`
 
-This command will run `ember test` with each scenario's specified in the config and exit appropriately.
+This command will run `ember test` or the configured command with each scenario's specified in the config and exit appropriately.
 
 This command is especially useful to use on CI to test against multiple `ember` versions.
 
-In order to use an alternate config path or to group various scenarios together in a single `try:testall` run, you can use
+In order to use an alternate config path or to group various scenarios together in a single `try:each` run, you can use
 the `--config-path` option.
 
 ```
-  ember try:testall --config-path="config/legacy-scenarios.js"
+  ember try:each --config-path="config/legacy-scenarios.js"
 ```
 
 If you need to know the scenario that is being ran (i.e. to customize a test output file name) you can use the `EMBER_TRY_CURRENT_SCENARIO`
@@ -34,7 +34,7 @@ environment variable.
 
 #### `ember try <scenario> <command (Default: test)>`
 
-This command will run any `ember-cli` command with the specified scenario. The command will default to `ember test`.
+This command will run any `ember-cli` command with the specified scenario. The command will default to `ember test`, if no command is specified on the command-line or in configuration.
 
 For example:
 
@@ -48,7 +48,7 @@ or
   ember try ember-1.11-with-ember-data-beta-16 serve
 ```
 
-When running in a CI environment where changes are discarded you can skip reseting your environment back to its original state by specifying --skip-cleanup=true as an option to ember try.
+When running in a CI environment where changes are discarded you can skip resetting your environment back to its original state by specifying --skip-cleanup=true as an option to ember try.
 *Warning: If you use this option and, without cleaning up, build and deploy as the result of a passing test suite, it will build with the last set of dependencies ember try was run with.*
 
 ```
@@ -65,15 +65,32 @@ In order to use an alternate config path or to group various scenarios, you can 
 
 This command restores the original `bower.json` from `bower.json.ember-try`, `rm -rf`s `bower_components` and runs `bower install`. For use if any of the other commands fail to clean up after (they run this by default on completion).
 
+
+#### ember try:testall
+
+Deprecated. This command was renamed to `ember try:each` to better reflect what it does. This command still works, though.
+
+
 ### Config
 
 Configuration will be read from a file in your ember app in `config/ember-try.js`. It should look like:
 
 ```js
 module.exports = {
+  /*
+    `command` - a single command that, if set, will be the default command used by `ember-try`.
+    P.S. The command doesn't need to be an `ember <something>` command, they can be anything.
+    Keep in mind that this config file is JavaScript, so you can code in here to determine the command. 
+  */
+  command: 'ember test --reporter xunit'
   scenarios: [
     {
       name: 'Ember 1.10 with ember-data',
+      
+      /*
+        `command` can also be overridden at the scenario level. 
+      */
+      command: 'ember test --filter ember-1-10'
       bower: {
         dependencies: {
           'ember': '1.10.0',

--- a/all-commands.sh
+++ b/all-commands.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 set -ex
 
+# try:each
+ember try:each
+
+# all styles of options for ember-try's own option
+ember try:each --skip-cleanup
+ember try:each --skip-cleanup=true
+ember try:each --skip-cleanup true
+
+# config-path option
+ember try:each --config-path='test/fixtures/dummy-ember-try-config.js'
+
+# both ember-try options
+ember try:each --config-path='test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
+
 # try:testall
 ember try:testall
 

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   try:         require('./try'),
   'try:testall': require('./testall'),
-  'try:reset':   require('./reset')
+  'try:reset':   require('./reset'),
+  'try:each': require('./try-each')
 };

--- a/lib/commands/testall.js
+++ b/lib/commands/testall.js
@@ -1,30 +1,8 @@
 'use strict';
+var TryEachCommand = require('./try-each');
+var extend = require('extend');
 
-module.exports = {
+module.exports = extend({}, TryEachCommand, {
   name: 'try:testall',
-  description: 'Runs `ember test` with each of the dependency scenarios specified in config.' ,
-  works: 'insideProject',
-
-  availableOptions: [
-    { name: 'skip-cleanup',  type: Boolean, default: false },
-    { name: 'config-path', type: String, default: 'config/ember-try.js' }
-  ],
-
-  _getConfig: require('../utils/config'),
-  _TryEachTask: require('../tasks/try-each'),
-
-  run: function(commandOptions, rawArgs) {
-    var config = this._getConfig({
-      project: this.project,
-      configPath: commandOptions.configPath
-    });
-
-    var tryEachTask = new this._TryEachTask({
-      ui: this.ui,
-      project: this.project,
-      config: config
-    });
-
-    return tryEachTask.run(config.scenarios, commandOptions);
-  }
-};
+  description: '(Deprecated, use try:each). Runs `ember test` with each of the dependency scenarios specified in config.'
+});

--- a/lib/commands/try-each.js
+++ b/lib/commands/try-each.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  name: 'try:each',
+  description: 'Runs each of the dependency scenarios specified in config with the specified command. The command defaults to `ember test`' ,
+  works: 'insideProject',
+
+  availableOptions: [
+    { name: 'skip-cleanup',  type: Boolean, default: false },
+    { name: 'config-path', type: String, default: 'config/ember-try.js' }
+  ],
+
+  _getConfig: require('../utils/config'),
+  _TryEachTask: require('../tasks/try-each'),
+  run: function(commandOptions, rawArgs) {
+    var config = this._getConfig({
+      project: this.project,
+      configPath: commandOptions.configPath
+    });
+
+    var tryEachTask = new this._TryEachTask({
+      ui: this.ui,
+      project: this.project,
+      config: config
+    });
+
+    return tryEachTask.run(config.scenarios, commandOptions);
+  }
+};

--- a/lib/commands/try.js
+++ b/lib/commands/try.js
@@ -19,7 +19,7 @@ module.exports = {
   _TryEachTask: require('../tasks/try-each'),
 
   getCommand: function(_argv) {
-    var args = (_argv || process.argv).slice();
+    var args = (_argv || this._commandLineArguments()).slice();
     var tryIndex = args.indexOf(this.name);
     var subcommandArgs = args.slice(tryIndex + 2);
     var skipIndex;
@@ -36,7 +36,7 @@ module.exports = {
     }
 
     if (subcommandArgs.length === 0) {
-      subcommandArgs.push('test');
+      return [];
     }
 
     subcommandArgs.unshift('ember');
@@ -46,6 +46,7 @@ module.exports = {
 
   run: function(commandOptions, rawArgs) {
     var scenarioName = rawArgs[0];
+
     var commandArgs = this.getCommand();
 
     if (!scenarioName) {
@@ -73,6 +74,10 @@ module.exports = {
     });
 
     return tryEachTask.run([scenario], commandOptions);
+  },
+
+  _commandLineArguments: function() {
+    return process.argv;
   }
 };
 

--- a/lib/commands/try.js
+++ b/lib/commands/try.js
@@ -39,6 +39,8 @@ module.exports = {
       subcommandArgs.push('test');
     }
 
+    subcommandArgs.unshift('ember');
+
     return subcommandArgs;
   },
 

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -52,33 +52,52 @@ module.exports = CoreObject.extend({
     return task.ScenarioManager.changeTo(scenario)
       .then(function(scenarioDependencyState) {
         process.env.EMBER_TRY_CURRENT_SCENARIO = scenario.name;
-
+        var command = task._determineCommandFor(scenario);
         var runResults = {
           scenario: scenario.name,
-          dependencyState: scenarioDependencyState
+          dependencyState: scenarioDependencyState,
+          command: command.join(' ')
         };
-        return task._runCommand().then(function(result) {
+
+        return task._runCommand({commandArgs: command, commandOptions: task._commandOptions()}).then(function(result) {
           runResults.result = result;
           return RSVP.resolve(runResults);
         });
       });
   },
 
-  _runCommand: function() {
+  _determineCommandFor: function(scenario) {
     var task = this;
-    return runCommand(task.project.root, this._commandArgs(), this._commandOptions());
+
+    if (task.commandArgs) {
+      return this.commandArgs;
+    }
+
+    if (scenario.command) {
+      return scenario.command.split(' ');
+    }
+
+    if (task.config.command) {
+      return task.config.command.split(' ');
+    }
+
+    return this._defaultCommandArgs();
+  },
+
+  _runCommand: function(options) {
+    return runCommand(this.project.root, options.commandArgs, options.commandOptions);
   },
 
   _commandOptions: function() {
     return this.commandOptions;
   },
 
-  _commandArgs: function() {
-    return this.commandArgs || ['test'];
+  _defaultCommandArgs: function() {
+    return ['ember', 'test'];
   },
 
   _printResults: function(results) {
-    new ResultSummary({ui: this.ui, results: results, command: this._commandArgs().join(' ')}).print();
+    new ResultSummary({ui: this.ui, results: results}).print();
   },
 
   _exitAsAppropriate: function(results) {

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -17,7 +17,7 @@ module.exports = CoreObject.extend({
     });
 
     var shutdownCount = 0;
-    process.on('SIGINT', function() {
+    task._on('SIGINT', function() {
       if (shutdownCount === 0) {
         shutdownCount++;
         task.ui.writeLine('\nGracefully shutting down from SIGINT (Ctrl-C)');
@@ -69,7 +69,7 @@ module.exports = CoreObject.extend({
   _determineCommandFor: function(scenario) {
     var task = this;
 
-    if (task.commandArgs) {
+    if (task.commandArgs && task.commandArgs.length) {
       return this.commandArgs;
     }
 
@@ -131,5 +131,10 @@ module.exports = CoreObject.extend({
 
   _exit: function(code) {
     process.exit(code);
+  },
+
+  _on: function(signal, fn) {
+    process.on(signal, fn);
   }
+
 });

--- a/lib/utils/result-summary.js
+++ b/lib/utils/result-summary.js
@@ -19,6 +19,7 @@ module.exports = CoreObject.extend({
         countFailed++;
       }
       task.ui.writeLine(colorAndMessage);
+      task.ui.writeLine('Command run: ' + scenario.command);
       task._printDependencyTable(scenario.dependencyState);
     });
 
@@ -29,8 +30,6 @@ module.exports = CoreObject.extend({
     var task = this;
     task.ui.writeLine('');
     task.ui.writeLine('------ RESULTS ------');
-    task.ui.writeLine('');
-    task.ui.writeLine('Running command `' + task.command + '`');
     task.ui.writeLine('');
   },
   _printDependencyTable: function(dependencyStatus) {

--- a/lib/utils/run-command.js
+++ b/lib/utils/run-command.js
@@ -4,13 +4,20 @@ var findEmberPath = require('./find-ember-path');
 var run           = require('./run');
 
 module.exports = function(root, commandArgs, opts) {
-  var options;
-  return findEmberPath(root)
-    .then(function(emberPath) {
-      options = extend({cwd: root}, opts);
-      return run('node', [].concat(emberPath, commandArgs), options);
-    })
-    .then(function() {
+  var options = extend({cwd: root}, opts);
+  var runPromise;
+  var command = commandArgs[0];
+  var actualArgs = commandArgs.slice(1);
+
+  if (command === 'ember') {
+    runPromise = findEmberPath(root).then(function(emberPath) {
+      return run('node', [].concat(emberPath, actualArgs), options);
+    });
+  } else {
+    runPromise = run(command, actualArgs, options);
+  }
+
+  return runPromise.then(function() {
       return RSVP.resolve(true);
     })
     .catch(function(errorCode) {

--- a/test/commands/try-each-test.js
+++ b/test/commands/try-each-test.js
@@ -1,8 +1,8 @@
 var should         = require('should');
-var TestallCommand = require('../../lib/commands/testall');
+var TryEachCommand = require('../../lib/commands/try-each');
 
-var origTryEachTask = TestallCommand._TryEachTask;
-var origGetConfig = TestallCommand._getConfig;
+var origTryEachTask = TryEachCommand._TryEachTask;
+var origGetConfig = TryEachCommand._getConfig;
 
 describe('commands/testall', function() {
   describe('#run', function() {
@@ -12,28 +12,28 @@ describe('commands/testall', function() {
     MockTryEachTask.prototype.run = function() { };
 
     beforeEach(function() {
-      TestallCommand._getConfig = function() {
+      TryEachCommand._getConfig = function() {
         return mockConfig || { scenarios: [ ] };
       };
 
-      TestallCommand._TryEachTask = MockTryEachTask;
+      TryEachCommand._TryEachTask = MockTryEachTask;
     });
 
     afterEach(function() {
-      TestallCommand._TryEachTask = origTryEachTask;
-      TestallCommand._getConfig = origGetConfig;
+      TryEachCommand._TryEachTask = origTryEachTask;
+      TryEachCommand._getConfig = origGetConfig;
       mockConfig = null;
     });
 
     it('should pass the configPath to _getConfig', function() {
       var configPath;
-      TestallCommand._getConfig = function(options) {
+      TryEachCommand._getConfig = function(options) {
         configPath = options.configPath;
 
         return { scenarios: [ { name: 'foo' }]};
       };
 
-      TestallCommand.run({ configPath: 'foo/bar/widget.js' }, ['foo']);
+      TryEachCommand.run({ configPath: 'foo/bar/widget.js' }, ['foo']);
       configPath.should.equal('foo/bar/widget.js');
     });
   });

--- a/test/commands/try-test.js
+++ b/test/commands/try-test.js
@@ -29,7 +29,7 @@ describe('commands/try', function() {
     it('adds `test` if no other subcommand arguments were supplied', function() {
       var args = TryCommand.getCommand(['ember', 'try', 'foo-bar-scenario']);
 
-      args.should.eql(['ember', 'test']);
+      args.should.eql([]);
     });
   });
 
@@ -76,5 +76,34 @@ describe('commands/try', function() {
         TryCommand.run({ }, ['foo']);
       }).should.throw(/requires a scenario specified in the config file/);
     });
+
+    it('should set command on task init', function() {
+      testCommandSetsTheseAsCommandArgs('try default', []);
+      testCommandSetsTheseAsCommandArgs('try default help', ['ember', 'help']);
+      testCommandSetsTheseAsCommandArgs('try default help --json', ['ember', 'help', '--json']);
+      testCommandSetsTheseAsCommandArgs('try default help --json=true', ['ember', 'help', '--json=true']);
+      testCommandSetsTheseAsCommandArgs('try default help --json true', ['ember', 'help', '--json', 'true']);
+    });
   });
 });
+
+function testCommandSetsTheseAsCommandArgs(command, expectedArgs) {
+  var additionalArgs = command.split(' ');
+  function MockTask(opts) {
+    opts.commandArgs.should.eql(expectedArgs);
+  }
+  MockTask.prototype.run = function() {
+  };
+  TryCommand._TryEachTask = MockTask;
+  TryCommand._commandLineArguments = function() {
+    return [].concat([ '/usr/local/Cellar/node/5.3.0/bin/node',
+                       '/usr/local/bin/ember'],
+                     additionalArgs);
+  };
+
+  TryCommand._getConfig = function(options) {
+    return { scenarios: [ { name: 'default' }]};
+  };
+
+  TryCommand.run({}, ['default']);
+}

--- a/test/commands/try-test.js
+++ b/test/commands/try-test.js
@@ -9,13 +9,13 @@ describe('commands/try', function() {
     it('removes `--skip-cleanup` from resulting arguments', function() {
       var args = TryCommand.getCommand(['ember', 'try', 'foo-bar-scenario', 'build', '--skip-cleanup']);
 
-      args.should.eql(['build']);
+      args.should.eql(['ember', 'build']);
     });
 
     it('removes `--config-path` from resulting arguments', function() {
       var args = TryCommand.getCommand(['ember', 'try', 'foo-bar-scenario', 'build', '--config-path']);
 
-      args.should.eql(['build']);
+      args.should.eql(['ember', 'build']);
     });
 
     it('removes both `--config-path` and `--skip-cleanup` from resulting arguments', function() {
@@ -23,13 +23,13 @@ describe('commands/try', function() {
         'ember', 'try', 'foo-bar-scenario', 'build', '--config-path', '--skip-cleanup'
       ]);
 
-      args.should.eql(['build']);
+      args.should.eql(['ember', 'build']);
     });
 
     it('adds `test` if no other subcommand arguments were supplied', function() {
       var args = TryCommand.getCommand(['ember', 'try', 'foo-bar-scenario']);
 
-      args.should.eql(['test']);
+      args.should.eql(['ember', 'test']);
     });
   });
 

--- a/test/helpers/generate-mock-run.js
+++ b/test/helpers/generate-mock-run.js
@@ -1,0 +1,58 @@
+module.exports = function generateMockRun() {
+  var mockedRuns = [];
+  if (typeof arguments[0] === 'string') {
+    mockedRuns.push({ command: arguments[0], callback: arguments[1] });
+  } else {
+    mockedRuns = arguments[0];
+  }
+
+  return function mockRun(actualCommand, actualArgs, opts) {
+    var matchingRun = mockedRuns.find(function(mockedRun) {
+      return isCommandMocked(mockedRun, actualCommand, actualArgs);
+    });
+
+    if (matchingRun) {
+      return matchingRun.callback(actualCommand, actualArgs, opts);
+    } else {
+      return passthrough().apply(this, arguments);
+    }
+  };
+};
+
+function isCommandMocked(mockedRun, actualCommand, actualArgs) {
+  var mockedRunParts = mockedRun.command.split(' ');
+  var mockedCommand = mockedRunParts[0];
+  var mockedArgs = mockedRunParts.slice(1);
+  return mockedCommandIsEmberAndArgumentsMatch(mockedCommand, mockedArgs, actualCommand, actualArgs) ||
+         commandIsMocked(mockedCommand, mockedArgs, actualCommand, actualArgs);
+}
+
+function passthrough(){
+  return require('../../lib/utils/run');
+}
+
+function mockedCommandIsEmberAndArgumentsMatch(mockedCommand, mockedArgs, actualCommand, actualArgs) {
+
+  return (mockedCommand === 'ember') &&
+         (actualCommand == 'node' && actualArgs && (actualArgs[0].indexOf('ember') > -1) &&
+         arraysAreEqual(actualArgs.slice(1), mockedArgs));
+}
+
+function commandIsMocked(mockedCommand, mockedArgs, actualCommand, actualArgs) {
+  return mockedCommand === actualCommand &&
+         arraysAreEqual(actualArgs, mockedArgs);
+}
+
+function arraysAreEqual(firstArr, secondArr) {
+  if (firstArr.length !== secondArr.length) {
+    return false;
+  }
+
+  for (var i=0; i < secondArr.length; i++) {
+    if(firstArr[i] !== secondArr[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/test/helpers/generate-mock-run.js
+++ b/test/helpers/generate-mock-run.js
@@ -7,9 +7,10 @@ module.exports = function generateMockRun() {
   }
 
   return function mockRun(actualCommand, actualArgs, opts) {
-    var matchingRun = mockedRuns.find(function(mockedRun) {
+    var matchingRuns = mockedRuns.filter(function(mockedRun) {
       return isCommandMocked(mockedRun, actualCommand, actualArgs);
     });
+    var matchingRun= matchingRuns[0];
 
     if (matchingRun) {
       return matchingRun.callback(actualCommand, actualArgs, opts);

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -141,6 +141,7 @@ describe('tryEach', function() {
         ui: {writeLine: outputFn},
         project: {root: tmpdir},
         config: legacyConfig,
+        _on: function() {},
         _exit: mockedExit
       });
 
@@ -189,6 +190,7 @@ describe('tryEach', function() {
         ui: {writeLine: outputFn},
         project: {root: tmpdir},
         config: legacyConfig,
+        _on: function() {},
         _exit: mockedExit
       });
 
@@ -233,6 +235,7 @@ describe('tryEach', function() {
         ui: {writeLine: outputFn},
         project: {root: tmpdir},
         config: config,
+        _on: function() {},
         _exit: mockedExit
       });
 
@@ -280,6 +283,7 @@ describe('tryEach', function() {
         ui: {writeLine: outputFn},
         project: {root: tmpdir},
         config: config,
+        _on: function() {},
         _exit: mockedExit
       });
 
@@ -341,6 +345,7 @@ describe('tryEach', function() {
         commandArgs: ['ember', 'serve'],
         commandOptions: { timeout: { length: 20000, isSuccess: true }},
         dependencyManagerAdapters: [new StubDependencyAdapter()],
+        _on: function() {},
         _exit: mockedExit
       });
 
@@ -355,6 +360,63 @@ describe('tryEach', function() {
     });
 
     describe('configurable command', function() {
+      it('defaults to `ember test`', function() {
+        // With stubbed dependency manager, timing out is warning for accidentally not using the stub
+        this.timeout(100);
+
+        var config = {
+          scenarios: [{
+            name: 'first',
+            dependencies: {
+              ember: '1.13.0'
+            }
+          },{
+            name: 'second',
+            dependencies: {
+              ember: '2.2.0'
+            }
+          }]
+        };
+
+        var ranDefaultCommand = false;
+
+        var mockedRun = generateMockRun('ember test', function() {
+            ranDefaultCommand = true;
+            return RSVP.resolve(0);
+        });
+
+        mockery.registerMock('./run', mockedRun);
+
+        var output = [];
+        var outputFn = function(log) {
+          output.push(log);
+        };
+
+        var mockedExit = function(code) {
+          code.should.equal(0, 'exits 0 when all scenarios succeed');
+        };
+
+        var TryEachTask = require('../../lib/tasks/try-each');
+        var tryEachTask = new TryEachTask({
+          ui: {writeLine: outputFn},
+          project: {root: tmpdir},
+          config: config,
+          commandArgs: [],
+          dependencyManagerAdapters: [new StubDependencyAdapter()],
+          _on: function() {},
+          _exit: mockedExit
+        });
+
+        return tryEachTask.run(config.scenarios, {}).then(function() {
+          output.should.containEql('Scenario first: SUCCESS');
+          output.should.containEql('Scenario second: SUCCESS');
+
+          ranDefaultCommand.should.equal(true, 'Should run the default command');
+        }).catch(function(err) {
+          true.should.equal(false, 'Assertions should run');
+        });
+      });
+
       it('allows passing in of the command to run', function() {
         // With stubbed dependency manager, timing out is warning for accidentally not using the stub
         this.timeout(100);
@@ -391,6 +453,7 @@ describe('tryEach', function() {
           config: config,
           commandArgs: ['ember', 'serve'],
           dependencyManagerAdapters: [new StubDependencyAdapter()],
+          _on: function() {},
           _exit: mockedExit
         });
 
@@ -460,6 +523,7 @@ describe('tryEach', function() {
           project: {root: tmpdir},
           config: config,
           dependencyManagerAdapters: [new StubDependencyAdapter()],
+          _on: function() {},
           _exit: mockedExit
         });
 
@@ -476,45 +540,45 @@ describe('tryEach', function() {
         });
       });
 
-    });
+      it('allows passing options to the command run', function() {
+        // With stubbed dependency manager, timing out is warning for accidentally not using the stub
+        this.timeout(5000);
 
-    it('allows passing options to the command run', function() {
-      // With stubbed dependency manager, timing out is warning for accidentally not using the stub
-      this.timeout(5000);
+        var config = {
+          scenarios: [{
+            name: 'first',
+            dependencies: {
+              ember: '1.13.0'
+            }
+          }]
+        };
 
-      var config = {
-        scenarios: [{
-          name: 'first',
-          dependencies: {
-            ember: '1.13.0'
-          }
-        }]
-      };
+        var output = [];
+        var outputFn = function(log) {
+          output.push(log);
+        };
 
-      var output = [];
-      var outputFn = function(log) {
-        output.push(log);
-      };
+        var mockedExit = function(code) {
+          code.should.equal(0, 'exits 0 when all scenarios succeed');
+        };
 
-      var mockedExit = function(code) {
-        code.should.equal(0, 'exits 0 when all scenarios succeed');
-      };
+        var TryEachTask = require('../../lib/tasks/try-each');
+        var tryEachTask = new TryEachTask({
+          ui: {writeLine: outputFn},
+          project: {root: tmpdir},
+          config: config,
+          commandArgs: ['ember', 'help', '--json', 'true'],
+          dependencyManagerAdapters: [new StubDependencyAdapter()],
+          _on: function() {},
+          _exit: mockedExit
+        });
 
-      var TryEachTask = require('../../lib/tasks/try-each');
-      var tryEachTask = new TryEachTask({
-        ui: {writeLine: outputFn},
-        project: {root: tmpdir},
-        config: config,
-        commandArgs: ['ember', 'help', '--json', 'true'],
-        dependencyManagerAdapters: [new StubDependencyAdapter()],
-        _exit: mockedExit
-      });
-
-      return tryEachTask.run(config.scenarios, {}).then(function() {
-        output.should.containEql('Scenario first: SUCCESS', 'Passing scenario means options were passed along');
-      }).catch(function(err) {
-        console.log(err);
-        true.should.equal(false, 'Assertions should run');
+        return tryEachTask.run(config.scenarios, {}).then(function() {
+          output.should.containEql('Scenario first: SUCCESS', 'Passing scenario means options were passed along');
+        }).catch(function(err) {
+          console.log(err);
+          true.should.equal(false, 'Assertions should run');
+        });
       });
     });
 
@@ -553,6 +617,7 @@ describe('tryEach', function() {
         project: {root: tmpdir},
         config: config,
         dependencyManagerAdapters: [new StubDependencyAdapter()],
+        _on: function() {},
         _exit: mockedExit,
         _runCommand: mockRunCommand
       });

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -9,6 +9,7 @@ var mockery       = require('mockery');
 
 /* The first two of the tests in this file intentionally DO NOT stub dependency manager adapter*/
 var StubDependencyAdapter = require('../helpers/stub-dependency-manager-adapter');
+var generateMockRun = require('../helpers/generate-mock-run');
 
 var remove = RSVP.denodeify(fs.remove);
 var root = process.cwd();
@@ -121,15 +122,9 @@ describe('tryEach', function() {
     it('succeeds when scenario\'s tests succeed', function() {
       this.timeout(30000);
 
-      var mockedRun = function(_, args) {
-        if (args[1].indexOf('test') > -1) {
-          return RSVP.resolve(0);
-        } else {
-          var regularRun = require('../../lib/utils/run');
-          return regularRun.apply(this, arguments);
-        }
-      };
-
+      var mockedRun = generateMockRun('ember test', function() {
+        return RSVP.resolve(0);
+      });
       mockery.registerMock('./run', mockedRun);
 
       var output = [];
@@ -169,19 +164,14 @@ describe('tryEach', function() {
       this.timeout(30000);
 
       var runTestCount = 0;
-      var mockedRun = function(_, args) {
-        if (args[1].indexOf('test') > -1) {
-          runTestCount++;
-          if (runTestCount == 1) {
-            return RSVP.reject(1);
-          } else {
-            return RSVP.resolve(0);
-          }
+      var mockedRun = generateMockRun('ember test', function() {
+        runTestCount++;
+        if (runTestCount == 1) {
+          return RSVP.reject(1);
         } else {
-          var regularRun = require('../../lib/utils/run');
-          return regularRun.apply(this, arguments);
+          return RSVP.resolve(0);
         }
-      };
+      });
 
       mockery.registerMock('./run', mockedRun);
 
@@ -223,14 +213,9 @@ describe('tryEach', function() {
     it('succeeds when scenario\'s tests succeed', function() {
       this.timeout(300000);
 
-      var mockedRun = function(cmd, args, opts) {
-        if (args && args.length > 1 && args[1].indexOf('test') > -1) {
-          return RSVP.resolve(0);
-        } else {
-          var regularRun = require('../../lib/utils/run');
-          return regularRun.apply(this, arguments);
-        }
-      };
+      var mockedRun = generateMockRun('ember test', function() {
+        return RSVP.resolve(0);
+      });
 
       mockery.registerMock('./run', mockedRun);
 
@@ -270,19 +255,14 @@ describe('tryEach', function() {
       this.timeout(300000);
 
       var runTestCount = 0;
-      var mockedRun = function(_, args) {
-        if (args && args.length > 1 && args[1].indexOf('test') > -1) {
-          runTestCount++;
-          if (runTestCount == 1) {
-            return RSVP.reject(1);
-          } else {
-            return RSVP.resolve(0);
-          }
+      var mockedRun = generateMockRun('ember test', function() {
+        runTestCount++;
+        if (runTestCount == 1) {
+          return RSVP.reject(1);
         } else {
-          var regularRun = require('../../lib/utils/run');
-          return regularRun.apply(this, arguments);
+          return RSVP.resolve(0);
         }
-      };
+      });
 
       mockery.registerMock('./run', mockedRun);
 
@@ -335,17 +315,12 @@ describe('tryEach', function() {
         }]
       };
       var passedInOptions = false;
-      var mockedRun = function(_, args, options) {
-        if (args[1].indexOf('serve') > -1) {
-          if(options.timeout && options.timeout.length == 20000 && options.timeout.isSuccess) {
-            passedInOptions = true;
-          }
-          return RSVP.resolve(0);
-        } else {
-          var regularRun = require('../../lib/utils/run');
-          return regularRun.apply(this, arguments);
+      var mockedRun = generateMockRun('ember serve', function(command, args, options) {
+        if (options.timeout && options.timeout.length == 20000 && options.timeout.isSuccess) {
+          passedInOptions = true;
         }
-      };
+        return RSVP.resolve(0);
+      });
 
       mockery.registerMock('./run', mockedRun);
 
@@ -363,7 +338,7 @@ describe('tryEach', function() {
         ui: {writeLine: outputFn},
         project: {root: tmpdir},
         config: config,
-        commandArgs: ['serve'],
+        commandArgs: ['ember', 'serve'],
         commandOptions: { timeout: { length: 20000, isSuccess: true }},
         dependencyManagerAdapters: [new StubDependencyAdapter()],
         _exit: mockedExit
@@ -379,58 +354,128 @@ describe('tryEach', function() {
       });
     });
 
-    it('allows passing in of the command to run', function() {
-      // With stubbed dependency manager, timing out is warning for accidentally not using the stub
-      this.timeout(100);
+    describe('configurable command', function() {
+      it('allows passing in of the command to run', function() {
+        // With stubbed dependency manager, timing out is warning for accidentally not using the stub
+        this.timeout(100);
 
-      var config = {
-        scenarios: [{
-          name: 'first',
-          dependencies: {
-            ember: '1.13.0'
-          }
-        }]
-      };
-      var ranPassedInCommand = false;
-      var mockedRun = function(_, args) {
-        if (args[1].indexOf('serve') > -1) {
+        var config = {
+          command: 'ember test-this',
+          scenarios: [{
+            name: 'first',
+            dependencies: {
+              ember: '1.13.0'
+            }
+          }]
+        };
+        var ranPassedInCommand = false;
+        var mockedRun = generateMockRun('ember serve', function() {
           ranPassedInCommand = true;
           return RSVP.resolve(0);
-        } else {
-          var regularRun = require('../../lib/utils/run');
-          return regularRun.apply(this, arguments);
-        }
-      };
+        });
+        mockery.registerMock('./run', mockedRun);
 
-      mockery.registerMock('./run', mockedRun);
+        var output = [];
+        var outputFn = function(log) {
+          output.push(log);
+        };
 
-      var output = [];
-      var outputFn = function(log) {
-        output.push(log);
-      };
+        var mockedExit = function(code) {
+          code.should.equal(0, 'exits 0 when all scenarios succeed');
+        };
 
-      var mockedExit = function(code) {
-        code.should.equal(0, 'exits 0 when all scenarios succeed');
-      };
+        var TryEachTask = require('../../lib/tasks/try-each');
+        var tryEachTask = new TryEachTask({
+          ui: {writeLine: outputFn},
+          project: {root: tmpdir},
+          config: config,
+          commandArgs: ['ember', 'serve'],
+          dependencyManagerAdapters: [new StubDependencyAdapter()],
+          _exit: mockedExit
+        });
 
-      var TryEachTask = require('../../lib/tasks/try-each');
-      var tryEachTask = new TryEachTask({
-        ui: {writeLine: outputFn},
-        project: {root: tmpdir},
-        config: config,
-        commandArgs: ['serve'],
-        dependencyManagerAdapters: [new StubDependencyAdapter()],
-        _exit: mockedExit
+        return tryEachTask.run(config.scenarios, {}).then(function() {
+          output.should.containEql('Scenario first: SUCCESS');
+          ranPassedInCommand.should.equal(true, 'Should run the passed in command');
+        }).catch(function(err) {
+          console.log(err);
+          true.should.equal(false, 'Assertions should run');
+        });
       });
 
-      writeJSONFile('bower.json', fixtureBower);
-      return tryEachTask.run(config.scenarios, {}).then(function() {
-        output.should.containEql('Scenario first: SUCCESS');
-        ranPassedInCommand.should.equal(true, 'Should run the passed in command');
-      }).catch(function(err) {
-        console.log(err);
-        true.should.equal(false, 'Assertions should run');
+      it('uses command from config', function() {
+        // With stubbed dependency manager, timing out is warning for accidentally not using the stub
+        this.timeout(100);
+
+        var config = {
+          command: 'ember test --test-port=2345',
+          scenarios: [{
+            name: 'first',
+            dependencies: {
+              ember: '1.13.0'
+            }
+          },{
+            name: 'second',
+            dependencies: {
+              ember: '2.2.0'
+            }
+          },{
+            name: 'different',
+            command: 'npm run-script different',
+            dependencies: {
+              ember: '2.0.0'
+            }
+          }]
+        };
+
+        var ranDefaultCommandCount = 0;
+        var ranScenarioCommandCount = 0;
+        var mockedRun = generateMockRun([{
+          command: 'ember test --test-port=2345',
+          callback: function() {
+            ranDefaultCommandCount++;
+            return RSVP.resolve(0);
+          }
+        },{
+          command: 'npm run-script different',
+          callback: function() {
+            ranScenarioCommandCount++;
+            return RSVP.resolve(0);
+          }
+        }]);
+        mockery.registerMock('./run', mockedRun);
+
+        var output = [];
+        var outputFn = function(log) {
+          output.push(log);
+        };
+
+        var mockedExit = function(code) {
+          code.should.equal(0, 'exits 0 when all scenarios succeed');
+        };
+
+        var TryEachTask = require('../../lib/tasks/try-each');
+        var tryEachTask = new TryEachTask({
+          ui: {writeLine: outputFn},
+          project: {root: tmpdir},
+          config: config,
+          dependencyManagerAdapters: [new StubDependencyAdapter()],
+          _exit: mockedExit
+        });
+
+        return tryEachTask.run(config.scenarios, {}).then(function() {
+          output.should.containEql('Scenario first: SUCCESS');
+          output.should.containEql('Scenario second: SUCCESS');
+          output.should.containEql('Scenario different: SUCCESS');
+
+          ranDefaultCommandCount.should.equal(2, 'Should run the default command scenarios without their own commands specified');
+          ranScenarioCommandCount.should.equal(1, 'Should run the scenario command for scenario that specified it');
+        }).catch(function(err) {
+          console.log(err);
+          true.should.equal(false, 'Assertions should run');
+        });
       });
+
     });
 
     it('allows passing options to the command run', function() {
@@ -460,7 +505,7 @@ describe('tryEach', function() {
         ui: {writeLine: outputFn},
         project: {root: tmpdir},
         config: config,
-        commandArgs: ['help', '--json', 'true'],
+        commandArgs: ['ember', 'help', '--json', 'true'],
         dependencyManagerAdapters: [new StubDependencyAdapter()],
         _exit: mockedExit
       });
@@ -507,7 +552,6 @@ describe('tryEach', function() {
         ui: {writeLine: outputFn},
         project: {root: tmpdir},
         config: config,
-        commandArgs: ['serve'],
         dependencyManagerAdapters: [new StubDependencyAdapter()],
         _exit: mockedExit,
         _runCommand: mockRunCommand

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -542,7 +542,7 @@ describe('tryEach', function() {
 
       it('allows passing options to the command run', function() {
         // With stubbed dependency manager, timing out is warning for accidentally not using the stub
-        this.timeout(5000);
+        this.timeout(10000);
 
         var config = {
           scenarios: [{

--- a/test/utils/run-command-test.js
+++ b/test/utils/run-command-test.js
@@ -29,7 +29,7 @@ describe('utils/run-command', function() {
 
     var runCommand  = require('../../lib/utils/run-command');
 
-    return runCommand('rootPath', ['help', '--json', 'true'], {}).then(function(result){
+    return runCommand('rootPath', ['ember', 'help', '--json', 'true'], {}).then(function(result){
       result.should.equal(true);
     });
   });


### PR DESCRIPTION
Commands can now be specified in configuration, both top-level and under each scenario. 

New command `ember try:each` that is an exact replacement for `ember try:testall`, with a new name that better fits the ability to configure commands. `ember try:testall` still works. 

Documentation commit coming soon. 