### PR TITLE
Add `ember try:one <scenario> (...options) --- <command>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ An ember-cli addon to test against multiple bower and npm dependencies, such as 
 ember install ember-try
 ```
 
-### Limitations
-
-Can only change versions for Ember 1.10+ due to template compiler changes that this addon does not attempt to handle.
-
 ### Usage
 
 This addon provides a few commands:
@@ -32,33 +28,33 @@ the `--config-path` option.
 If you need to know the scenario that is being ran (i.e. to customize a test output file name) you can use the `EMBER_TRY_CURRENT_SCENARIO`
 environment variable.
 
-#### `ember try <scenario> <command (Default: test)>`
+#### `ember try:one <scenario> (...options) --- <command (Default: test)>`
 
 This command will run any `ember-cli` command with the specified scenario. The command will default to `ember test`, if no command is specified on the command-line or in configuration.
 
 For example:
 
 ```
-  ember try ember-1.11-with-ember-data-beta-16 test
+  ember try:one ember-1.11-with-ember-data-beta-16 --- ember test --reporter xunit
 ```
 
 or
 
 ```
-  ember try ember-1.11-with-ember-data-beta-16 serve
+  ember try:one ember-1.11-with-ember-data-beta-16 --- ember serve
 ```
 
 When running in a CI environment where changes are discarded you can skip resetting your environment back to its original state by specifying --skip-cleanup=true as an option to ember try.
 *Warning: If you use this option and, without cleaning up, build and deploy as the result of a passing test suite, it will build with the last set of dependencies ember try was run with.*
 
 ```
-  ember try ember-1.11 test --skip-cleanup=true
+  ember try:one ember-1.11 --skip-cleanup=true --- ember test
 ```
 
 In order to use an alternate config path or to group various scenarios, you can use the `--config-path` option.
 
 ```
-  ember try ember-1.13 test --config-path="config/legacy-scenarios.js"
+  ember try:one ember-1.13 --config-path="config/legacy-scenarios.js"
 ```
 
 #### `ember try:reset`
@@ -66,9 +62,13 @@ In order to use an alternate config path or to group various scenarios, you can 
 This command restores the original `bower.json` from `bower.json.ember-try`, `rm -rf`s `bower_components` and runs `bower install`. For use if any of the other commands fail to clean up after (they run this by default on completion).
 
 
-#### ember try:testall
+#### (DEPRECATED) ember try:testall
 
-Deprecated. This command was renamed to `ember try:each` to better reflect what it does. This command still works, though.
+This command was renamed to `ember try:each` to better reflect what it does. This command still works, though.
+
+#### (DEPRECATED) `ember try <scenario> <command (Default: test)>`
+
+This command is deprecated in favor of `ember try:one`. There are several bugs with passing options to the specified command that will not be fixed.
 
 
 ### Config
@@ -138,7 +138,7 @@ module.exports = {
 ```
 
 Scenarios are sets of dependencies (`bower` and `npm` only). They can be specified exactly as in the `bower.json` or `package.json`
-The `name` can be used to try just one scenario using the `ember try` command.
+The `name` can be used to try just one scenario using the `ember try:one` command.
 
 If no `config/ember-try.js` file is present, the default config will be used. This is the current default config:
 

--- a/all-commands.sh
+++ b/all-commands.sh
@@ -15,7 +15,7 @@ ember try:each --config-path='test/fixtures/dummy-ember-try-config.js'
 # both ember-try options
 ember try:each --config-path='test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
 
-# try:testall
+# try:testall (Deprecated)
 ember try:testall
 
 # all styles of options for ember-try's own option
@@ -29,7 +29,7 @@ ember try:testall --config-path='test/fixtures/dummy-ember-try-config.js'
 # both ember-try options
 ember try:testall --config-path='test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
 
-# try <scenario>
+# try <scenario>  (Deprecated)
 ember try default
 
 # custom command
@@ -55,6 +55,32 @@ ember try default help --json true
 
 # custom command mixed with ember try's own option
 ember try default help --json --skip-cleanup
+
+# try:one <scenario>
+ember try:one default
+
+# custom command
+ember try:one default --- ember help
+
+# skip-cleanup option
+ember try:one default --skip-cleanup
+ember try:one default --skip-cleanup=true
+ember try:one default --skip-cleanup true
+
+# config-path option
+ember try:one test1 --config-path='test/fixtures/dummy-ember-try-config.js'
+
+# both ember-try options
+ember try:one test1 --config-path='test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
+
+# custom command with all styles of options
+ember try:one default --- ember help --json
+ember try:one default --- ember help --json=true
+ember try:one default --- ember help --json true
+
+# custom command mixed with ember try's own option
+ember try:one default --skip-cleanup --- ember help --json
+
 
 # try:reset
 ember try:reset

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -2,5 +2,6 @@ module.exports = {
   try:         require('./try'),
   'try:testall': require('./testall'),
   'try:reset':   require('./reset'),
-  'try:each': require('./try-each')
+  'try:each': require('./try-each'),
+  'try:one': require('./try-one')
 };

--- a/lib/commands/try-one.js
+++ b/lib/commands/try-one.js
@@ -1,13 +1,12 @@
 'use strict';
 
 module.exports = {
-  name: 'try',
-  description: 'Run any `ember` command with the specified dependency scenario',
+  name: 'try:one',
+  description: 'Run any `ember` command with the specified dependency scenario. Takes an optional command,; put it after any options, preceded by " --- "',
   works: 'insideProject',
 
   anonymousOptions: [
-    '<scenario>',
-    '<command (Default: test)>'
+    '<scenario>'
   ],
 
   availableOptions: [
@@ -20,38 +19,21 @@ module.exports = {
 
   getCommand: function(_argv) {
     var args = (_argv || this._commandLineArguments()).slice();
-    var tryIndex = args.indexOf(this.name);
-    var subcommandArgs = args.slice(tryIndex + 2);
-    var skipIndex;
-
-    // Remove ember-try options from the args that are passed on to ember
-    skipIndex = subcommandArgs.indexOf('--skip-cleanup');
-    if (skipIndex !== -1) {
-      subcommandArgs.splice(skipIndex, 1);
-    }
-
-    skipIndex = subcommandArgs.indexOf('--config-path');
-    if (skipIndex !== -1) {
-      subcommandArgs.splice(skipIndex, 1);
-    }
-
-    if (subcommandArgs.length === 0) {
+    var separatorIndex = args.indexOf('---');
+    if(separatorIndex === -1) {
       return [];
     }
 
-    subcommandArgs.unshift('ember');
-
-    return subcommandArgs;
+    return args.slice(separatorIndex + 1);
   },
 
   run: function(commandOptions, rawArgs) {
-    this.ui.writeDeprecateLine("This command is deprecated in favor of `ember try:one`.\nExample: `ember try default-scenario serve --port 4201`, becomes:\n`ember try:one default-scenario --- ember serve --port 4201`");
     var scenarioName = rawArgs[0];
 
     var commandArgs = this.getCommand();
 
     if (!scenarioName) {
-      throw new Error('The `ember try` command requires a ' +
+      throw new Error('The `ember try:one` command requires a ' +
                       'scenario name to be specified.');
     }
 
@@ -63,7 +45,7 @@ module.exports = {
     var scenario = findByName(config.scenarios, scenarioName);
 
     if (!scenario) {
-      throw new Error('The `ember try` command requires a scenario ' +
+      throw new Error('The `ember try:one` command requires a scenario ' +
                       'specified in the config file.');
     }
 

--- a/test/commands/try-one-test.js
+++ b/test/commands/try-one-test.js
@@ -1,0 +1,93 @@
+var should        = require('should');
+var TryOneCommand    = require('../../lib/commands/try-one');
+
+var origTryEachTask = TryOneCommand._TryEachTask;
+var origGetConfig = TryOneCommand._getConfig;
+
+describe('commands/try-one', function() {
+  describe('getCommand', function() {
+    it('returns args after --- as command args', function() {
+      var args = TryOneCommand.getCommand(['ember', 'try:one', 'foo-bar-scenario', '--skip-cleanup', '---', 'ember', 'build']);
+      args.should.eql(['ember', 'build']);
+    });
+
+    it('returns no command args if no ---', function() {
+      var args = TryOneCommand.getCommand(['ember', 'try:one', 'foo-bar-scenario', '--skip-cleanup']);
+      args.should.eql([]);
+    });
+  });
+
+  describe('#run', function() {
+    var mockConfig;
+
+    function MockTryEachTask() { }
+    MockTryEachTask.prototype.run = function() { };
+
+    beforeEach(function() {
+      TryOneCommand._getConfig = function() {
+        return mockConfig || { scenarios: [ ] };
+      };
+
+      TryOneCommand._TryEachTask = MockTryEachTask;
+    });
+
+    afterEach(function() {
+      TryOneCommand._TryEachTask = origTryEachTask;
+      TryOneCommand._getConfig = origGetConfig;
+      mockConfig = null;
+    });
+
+    it('should throw if no scenario is provided', function() {
+      (function() {
+        TryOneCommand.run({}, []);
+      }).should.throw(/requires a scenario name to be specified/);
+    });
+
+    it('should pass the configPath to _getConfig', function() {
+      var configPath;
+      TryOneCommand._getConfig = function(options) {
+        configPath = options.configPath;
+
+        return { scenarios: [ { name: 'foo' }]};
+      };
+
+      TryOneCommand.run({ configPath: 'foo/bar/widget.js' }, ['foo']);
+      configPath.should.equal('foo/bar/widget.js');
+    });
+
+    it('should throw if a scenario was not found for the scenarioName provided', function() {
+      (function() {
+        TryOneCommand.run({ }, ['foo']);
+      }).should.throw(/requires a scenario specified in the config file/);
+    });
+
+    it('should set command on task init', function() {
+      testCommandSetsTheseAsCommandArgs('try:one default', []);
+      testCommandSetsTheseAsCommandArgs('try:one default --- ember help', ['ember', 'help']);
+      testCommandSetsTheseAsCommandArgs('try:one default --- ember help --json', ['ember', 'help', '--json']);
+      testCommandSetsTheseAsCommandArgs('try:one default --- ember help --json=true', ['ember', 'help', '--json=true']);
+      testCommandSetsTheseAsCommandArgs('try:one default --- ember help --json true', ['ember', 'help', '--json', 'true']);
+    });
+  });
+});
+
+function testCommandSetsTheseAsCommandArgs(command, expectedArgs) {
+  var additionalArgs = command.split(' ');
+  function MockTask(opts) {
+    opts.commandArgs.should.eql(expectedArgs);
+  }
+  MockTask.prototype.run = function() {
+  };
+  TryOneCommand._TryEachTask = MockTask;
+  TryOneCommand._commandLineArguments = function() {
+    return [].concat([ '/usr/local/Cellar/node/5.3.0/bin/node',
+                       '/usr/local/bin/ember'],
+                     additionalArgs);
+  };
+
+  TryOneCommand._getConfig = function(options) {
+    return { scenarios: [ { name: 'default' }]};
+  };
+
+  TryOneCommand.run({}, ['default']);
+}

--- a/test/commands/try-test.js
+++ b/test/commands/try-test.js
@@ -44,6 +44,8 @@ describe('commands/try', function() {
         return mockConfig || { scenarios: [ ] };
       };
 
+      TryCommand.ui = { writeDeprecateLine: function () {} };
+
       TryCommand._TryEachTask = MockTryEachTask;
     });
 


### PR DESCRIPTION
- Replaces `ember try <scenario`
- Allows commands other than `ember <something>`
- Allows more robust handling of options passed to the command and to
  ember-try