### PR TITLE
Add 'bowerOptions' and 'npmOptions' as top level configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ module.exports = {
     Keep in mind that this config file is JavaScript, so you can code in here to determine the command. 
   */
   command: 'ember test --reporter xunit'
+  /*
+    `bowerOptions` - options to be passed to `bower`.
+  */
+  bowerOptions: ['--allow-root=true'],
+  /*
+    `npmOptions` - options to be passed to `npm`.
+  */
+  npmOptions: ['--loglevel=silent', '--no-shrinkwrap=true'],
   scenarios: [
     {
       name: 'Ember 1.10 with ember-data',

--- a/lib/utils/bower-adapter.js
+++ b/lib/utils/bower-adapter.js
@@ -69,13 +69,14 @@ module.exports = CoreObject.extend({
   },
   _install: function() {
     var adapter = this;
+    var options = this.managerOptions || [];
 
     return rimraf(path.join(adapter.cwd, 'bower_components'))
       .then(function() {
         return adapter._findBowerPath(adapter.cwd);
       })
       .then(function(bowerPath) {
-        return adapter.run('node', [bowerPath, 'install', '--config.interactive=false'], {cwd: adapter.cwd});
+        return adapter.run('node', [].concat([bowerPath, 'install', '--config.interactive=false'], options), {cwd: adapter.cwd});
       });
   },
   _bowerJSONForDependencySet: function(bowerJSON, depSet) {

--- a/lib/utils/dependency-manager-adapter-factory.js
+++ b/lib/utils/dependency-manager-adapter-factory.js
@@ -19,10 +19,10 @@ module.exports = {
       }
     });
     if (hasNpm) {
-      adapters.push(new NpmAdapter({cwd: root}));
+      adapters.push(new NpmAdapter({cwd: root, managerOptions: config.npmOptions}));
     }
     if (hasBower) {
-      adapters.push(new BowerAdapter({cwd: root}));
+      adapters.push(new BowerAdapter({cwd: root, managerOptions: config.bowerOptions}));
     }
     return adapters;
   }

--- a/lib/utils/npm-adapter.js
+++ b/lib/utils/npm-adapter.js
@@ -63,8 +63,9 @@ module.exports = CoreObject.extend({
   },
   _install: function() {
     var adapter = this;
-    return adapter.run('npm', ['install'], {cwd: adapter.cwd}).then(function() {
-      return adapter.run('npm', ['prune'], {cwd: adapter.cwd});
+    var options = this.managerOptions || [];
+    return adapter.run('npm', [].concat(['install'], options), {cwd: adapter.cwd}).then(function() {
+      return adapter.run('npm', [].concat(['prune'], options), {cwd: adapter.cwd});
     });
   },
   _packageJSONForDependencySet: function(packageJSON, depSet) {

--- a/test/bower-adapter-test.js
+++ b/test/bower-adapter-test.js
@@ -108,11 +108,23 @@ describe('bowerAdapter', function() {
         args[1].should.equal('install');
         args[2].should.equal('--config.interactive=false');
         opts.should.have.property('cwd', tmpdir);
-        return new RSVP.Promise(function(resolve, reject) {
-          resolve();
-        });
+        return RSVP.resolve();
       };
       return new BowerAdapter({cwd: tmpdir, run: stubbedRun})._install();
+    });
+
+    it('runs bower install including managerOptions', function() {
+      writeJSONFile('bower.json', fixtureBower);
+      var stubbedRun = function(command, args, opts) {
+        command.should.equal('node');
+        args[0].should.match(/bower/);
+        args[1].should.equal('install');
+        args[2].should.equal('--config.interactive=false');
+        args[3].should.equal('--verbose=true');
+        args[4].should.equal('--allow-root=true');
+        return RSVP.resolve();
+      };
+      return new BowerAdapter({cwd: tmpdir, run: stubbedRun, managerOptions: ['--verbose=true', '--allow-root=true']})._install();
     });
   });
 

--- a/test/helpers/generate-mock-run.js
+++ b/test/helpers/generate-mock-run.js
@@ -1,9 +1,13 @@
+var extend = require('extend');
+
 module.exports = function generateMockRun() {
   var mockedRuns = [];
+  var options = { allowPassthrough: true };
   if (typeof arguments[0] === 'string') {
     mockedRuns.push({ command: arguments[0], callback: arguments[1] });
   } else {
     mockedRuns = arguments[0];
+    options = extend({}, options, arguments[1]);
   }
 
   return function mockRun(actualCommand, actualArgs, opts) {
@@ -15,7 +19,11 @@ module.exports = function generateMockRun() {
     if (matchingRun) {
       return matchingRun.callback(actualCommand, actualArgs, opts);
     } else {
-      return passthrough().apply(this, arguments);
+      if(options.allowPassthrough) {
+        return passthrough().apply(this, arguments);
+      } else {
+        throw new Error(actualCommand + ' ' + actualArgs.join(' ') + ' not stubbed and not allowed to passthrough');
+      }
     }
   };
 };


### PR DESCRIPTION
- Each are passed to their respective package manager's commands that
  are run by `ember-try`
- Both are arrays of options as strings, example: `bowerOptions:
  ['--allow-root']`