### PR TITLE
New configuration option `allowedToFail` per scenario.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ module.exports = {
     },
     {
       name: 'Ember canary with Ember-Data 2.3.0',
+      /*
+        `allowedToFail` - If true, if this scenario fails it will not fail the entire try command.
+      */
+      allowedToFail: true,
       npm: {
         devDependencies: {
           'ember-data': '2.3.0'

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -55,6 +55,7 @@ module.exports = CoreObject.extend({
         var command = task._determineCommandFor(scenario);
         var runResults = {
           scenario: scenario.name,
+          allowedToFail: !!scenario.allowedToFail,
           dependencyState: scenarioDependencyState,
           command: command.join(' ')
         };
@@ -102,7 +103,7 @@ module.exports = CoreObject.extend({
 
   _exitAsAppropriate: function(results) {
     var outcomes = results.map(function(result) {
-      return result.result;
+      return result.result || result.allowedToFail;
     });
     this._exitBasedOnCondition(outcomes.indexOf(false) > -1);
   },

--- a/lib/utils/result-summary.js
+++ b/lib/utils/result-summary.js
@@ -6,8 +6,10 @@ module.exports = CoreObject.extend({
   print: function() {
     var task = this;
     var colorAndMessage;
+    var failMessage;
     var countPassed = 0;
     var countFailed = 0;
+    var allowedFailCount = 0;
     task._printResultHeader();
 
     this.results.forEach(function(scenario, index) {
@@ -15,7 +17,14 @@ module.exports = CoreObject.extend({
         colorAndMessage = chalk.green('Scenario ' + scenario.scenario + ': SUCCESS');
         countPassed++;
       } else {
-        colorAndMessage = chalk.red('Scenario ' + scenario.scenario + ': FAIL');
+        failMessage = 'Scenario ' + scenario.scenario + ': FAIL';
+
+        if (scenario.allowedToFail) {
+          failMessage = failMessage + ' (Allowed)';
+          allowedFailCount++;
+        }
+
+        colorAndMessage = chalk.red(failMessage);
         countFailed++;
       }
       task.ui.writeLine(colorAndMessage);
@@ -24,7 +33,7 @@ module.exports = CoreObject.extend({
     });
 
     task.ui.writeLine('');
-    task._printResultsSummary(countFailed, countPassed, this.results.length);
+    task._printResultsSummary(countFailed, countPassed, allowedFailCount, this.results.length);
   },
   _printResultHeader: function() {
     var task = this;
@@ -55,10 +64,14 @@ module.exports = CoreObject.extend({
     task.ui.writeLine(table);
     task.ui.writeLine('');
   },
-  _printResultsSummary: function(countFailed, countPassed, total) {
+  _printResultsSummary: function(countFailed, countPassed, allowedFailCount, total) {
     var task = this;
     if (countFailed) {
-      task.ui.writeLine(chalk.red(countFailed + ' scenarios failed'));
+      var failMessage = countFailed + ' scenarios failed';
+      if(allowedFailCount) {
+        failMessage = failMessage + ' (' + allowedFailCount + ' allowed)';
+      }
+      task.ui.writeLine(chalk.red(failMessage));
       task.ui.writeLine(chalk.green(countPassed + ' scenarios succeeded'));
       task.ui.writeLine(chalk.gray(total + ' scenarios run'));
     } else {

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -359,6 +359,179 @@ describe('tryEach', function() {
       });
     });
 
+    describe('allowedToFail', function() {
+      it('exits appropriately if all failures were allowedToFail', function() {
+        // With stubbed dependency manager, timing out is warning for accidentally not using the stub
+        this.timeout(100);
+
+        var config = {
+          scenarios: [{
+            name: 'first',
+            allowedToFail: true,
+            dependencies: {
+              ember: '1.13.0'
+            }
+          },{
+            name: 'second',
+            allowedToFail: true,
+            dependencies: {
+              ember: '2.2.0'
+            }
+          }]
+        };
+
+        var ranDefaultCommandCount = 0;
+        var ranScenarioCommandCount = 0;
+        var mockedRun = generateMockRun('ember test', function() {
+          return RSVP.reject(1);
+        });
+        mockery.registerMock('./run', mockedRun);
+
+        var output = [];
+        var outputFn = function(log) {
+          output.push(log);
+        };
+        var exitCode;
+        var mockedExit = function(code) {
+          exitCode = code;
+        };
+
+        var TryEachTask = require('../../lib/tasks/try-each');
+        var tryEachTask = new TryEachTask({
+          ui: {writeLine: outputFn},
+          project: {root: tmpdir},
+          config: config,
+          dependencyManagerAdapters: [new StubDependencyAdapter()],
+          _on: function() {},
+          _exit: mockedExit
+        });
+
+        return tryEachTask.run(config.scenarios, {}).then(function() {
+          output.should.containEql('Scenario first: FAIL (Allowed)');
+          output.should.containEql('Scenario second: FAIL (Allowed)');
+          output.should.containEql('2 scenarios failed (2 allowed)');
+          exitCode.should.equal(0, 'exits 0 when all failures were allowed');
+        }).catch(function(err) {
+          console.log(err);
+          true.should.equal(false, 'Assertions should run');
+        });
+      });
+
+      it('exits appropriately if any failures were not allowedToFail', function() {
+        // With stubbed dependency manager, timing out is warning for accidentally not using the stub
+        this.timeout(100);
+
+        var config = {
+          scenarios: [{
+            name: 'first',
+            dependencies: {
+              ember: '1.13.0'
+            }
+          },{
+            name: 'second',
+            allowedToFail: true,
+            dependencies: {
+              ember: '2.2.0'
+            }
+          }]
+        };
+
+        var ranDefaultCommandCount = 0;
+        var ranScenarioCommandCount = 0;
+        var mockedRun = generateMockRun('ember test', function() {
+          return RSVP.reject(1);
+        });
+        mockery.registerMock('./run', mockedRun);
+
+        var output = [];
+        var outputFn = function(log) {
+          output.push(log);
+        };
+        var exitCode;
+        var mockedExit = function(code) {
+          exitCode = code;
+        };
+
+        var TryEachTask = require('../../lib/tasks/try-each');
+        var tryEachTask = new TryEachTask({
+          ui: {writeLine: outputFn},
+          project: {root: tmpdir},
+          config: config,
+          dependencyManagerAdapters: [new StubDependencyAdapter()],
+          _on: function() {},
+          _exit: mockedExit
+        });
+
+        return tryEachTask.run(config.scenarios, {}).then(function() {
+          output.should.containEql('Scenario first: FAIL');
+          output.should.containEql('Scenario second: FAIL (Allowed)');
+          output.should.containEql('2 scenarios failed (1 allowed)');
+          exitCode.should.equal(1, 'exits 1 when any failures were NOT allowed');
+        }).catch(function(err) {
+          console.log(err);
+          true.should.equal(false, 'Assertions should run');
+        });
+      });
+
+      it('exits appropriately if all allowedToFail pass', function() {
+        // With stubbed dependency manager, timing out is warning for accidentally not using the stub
+        this.timeout(100);
+
+        var config = {
+          scenarios: [{
+            name: 'first',
+            allowedToFail: true,
+            dependencies: {
+              ember: '1.13.0'
+            }
+          },{
+            name: 'second',
+            allowedToFail: true,
+            dependencies: {
+              ember: '2.2.0'
+            }
+          }]
+        };
+
+        var ranDefaultCommandCount = 0;
+        var ranScenarioCommandCount = 0;
+        var mockedRun = generateMockRun('ember test', function() {
+          return RSVP.resolve(0);
+        });
+        mockery.registerMock('./run', mockedRun);
+
+        var output = [];
+        var outputFn = function(log) {
+          output.push(log);
+        };
+        var exitCode;
+        var mockedExit = function(code) {
+          exitCode = code;
+        };
+
+        var TryEachTask = require('../../lib/tasks/try-each');
+        var tryEachTask = new TryEachTask({
+          ui: {writeLine: outputFn},
+          project: {root: tmpdir},
+          config: config,
+          dependencyManagerAdapters: [new StubDependencyAdapter()],
+          _on: function() {},
+          _exit: mockedExit
+        });
+
+        return tryEachTask.run(config.scenarios, {}).then(function() {
+          output.should.containEql('Scenario first: SUCCESS');
+          output.should.containEql('Scenario second: SUCCESS');
+          output.should.containEql('All 2 scenarios succeeded');
+          exitCode.should.equal(0, 'exits 0 when all pass');
+        }).catch(function(err) {
+          console.log(err);
+          true.should.equal(false, 'Assertions should run');
+        });
+      });
+
+    });
+
     describe('configurable command', function() {
       it('defaults to `ember test`', function() {
         // With stubbed dependency manager, timing out is warning for accidentally not using the stub


### PR DESCRIPTION
- If set, the scenario will not fail the overall `ember try` command that was run

Fixes #4 